### PR TITLE
Add meson build files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,24 @@
+project('nitrogfx', 'c')
+
+native = get_option('native')
+
+libpng_dep = dependency('libpng', native: native)
+
+nitrogfx_exe = executable('nitrogfx',
+    sources: [
+        'main.c',
+        'convert_png.c',
+        'gfx.c',
+        'jasc_pal.c',
+        'lz.c',
+        'rl.c',
+        'util.c',
+        'font.c',
+        'huff.c',
+        'json.c',
+        'cJSON.c',
+    ],
+    dependencies: libpng_dep,
+    native: native,
+    install: true
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('native', type : 'boolean', value : false, description: 'Force native compilation, even in a cross-compilation setup')


### PR DESCRIPTION
This PR adds two simple files (meson.build and meson_options.txt) to allow building the project with Meson.