### PR TITLE
Fix cross-compiling in Meson with 'native' option on

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('nitrogfx', 'c')
 
 native = get_option('native')
+install = native and meson.is_cross_build() ? false : true
 
 libpng_dep = dependency('libpng', native: native)
 
@@ -20,5 +21,5 @@ nitrogfx_exe = executable('nitrogfx',
     ],
     dependencies: libpng_dep,
     native: native,
-    install: true
+    install: install
 )


### PR DESCRIPTION
Cross-compiling in Meson with the 'native' option from meson_options.txt set to 'true' yields the Meson error:

`ERROR: tried to install a target for the build machine in a cross build.`

This PR disables installing in such a setting.