### PR TITLE
Add override_find_program() to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,3 +23,5 @@ nitrogfx_exe = executable('nitrogfx',
     native: native,
     install: install
 )
+
+meson.override_find_program('nitrogfx', nitrogfx_exe)


### PR DESCRIPTION
Forgot to add meson.override_find_program('nitrogfx', nitrogfx_exe) in my previous commits. It is necessary for other Meson projects to be able to use nitrogfx as a subproject with wrap files.