### PR TITLE
Refactored variable names for readability and added comments

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -19,10 +19,10 @@
 
 #define DOWNCONVERT_BIT_DEPTH(x) ((x) / 8)
 
-static void AdvanceTilePosition(int *tilesSoFar, int *rowsSoFar, int *chunkStartX, int *chunkStartY, int chunksWide, int tilesPerRow, int rowsPerChunk)
+static void AdvanceTilePosition(int *tilesSoFar, int *rowsSoFar, int *chunkStartX, int *chunkStartY, int chunksWide, int colsPerChunk, int rowsPerChunk)
 {
     (*tilesSoFar)++;
-    if (*tilesSoFar == tilesPerRow) {
+    if (*tilesSoFar == colsPerChunk) {
         *tilesSoFar = 0;
         (*rowsSoFar)++;
         if (*rowsSoFar == rowsPerChunk) {
@@ -36,18 +36,18 @@ static void AdvanceTilePosition(int *tilesSoFar, int *rowsSoFar, int *chunkStart
     }
 }
 
-static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = chunksWide * tilesPerRow;
+    int pitch = chunksWide * colsPerChunk;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
-            int idxComponentX = chunkStartX * tilesPerRow + tilesSoFar;
+            int idxComponentX = chunkStartX * colsPerChunk + tilesSoFar;
             unsigned char srcPixelOctet = *src++;
             unsigned char *destPixelOctet = &dest[idxComponentY * pitch + idxComponentX];
 
@@ -58,24 +58,24 @@ static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int nu
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
-static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = (chunksWide * tilesPerRow) * 4;
+    int pitch = (chunksWide * colsPerChunk) * 4;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
+                int idxComponentX = (chunkStartX * colsPerChunk + tilesSoFar) * 4 + k;
                 unsigned char srcPixelPair = *src++;
                 unsigned char leftPixel = srcPixelPair & 0xF;
                 unsigned char rightPixel = srcPixelPair >> 4;
@@ -89,7 +89,7 @@ static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int nu
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
@@ -135,20 +135,20 @@ static uint32_t ConvertFromScanned4Bpp(unsigned char *src, unsigned char *dest, 
     return encValue;
 }
 
-static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = (chunksWide * tilesPerRow) * 8;
+    int pitch = (chunksWide * colsPerChunk) * 8;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
+                int idxComponentX = (chunkStartX * colsPerChunk + tilesSoFar) * 8 + k;
                 unsigned char srcPixel = *src++;
 
                 if (invertColors)
@@ -158,7 +158,7 @@ static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int nu
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
@@ -201,18 +201,18 @@ static uint32_t ConvertFromScanned8Bpp(unsigned char *src, unsigned char *dest, 
     return encValue;
 }
 
-static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = chunksWide * tilesPerRow;
+    int pitch = chunksWide * colsPerChunk;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
-            int idxComponentX = chunkStartX * tilesPerRow + tilesSoFar;
+            int idxComponentX = chunkStartX * colsPerChunk + tilesSoFar;
             unsigned char srcPixelOctet = src[idxComponentY * pitch + idxComponentX];
             unsigned char *destPixelOctet = dest++;
 
@@ -223,24 +223,24 @@ static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
-static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = (chunksWide * tilesPerRow) * 4;
+    int pitch = (chunksWide * colsPerChunk) * 4;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
+                int idxComponentX = (chunkStartX * colsPerChunk + tilesSoFar) * 4 + k;
                 unsigned char srcPixelPair = src[idxComponentY * pitch + idxComponentX];
                 unsigned char leftPixel = srcPixelPair >> 4;
                 unsigned char rightPixel = srcPixelPair & 0xF;
@@ -254,7 +254,7 @@ static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
@@ -294,20 +294,20 @@ static void ConvertToScanned4Bpp(unsigned char *src, unsigned char *dest, int fi
     }
 }
 
-static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
+static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int colsPerChunk, int rowsPerChunk, bool invertColors)
 {
     int tilesSoFar = 0;
     int rowsSoFar = 0;
     int chunkStartX = 0;
     int chunkStartY = 0;
-    int pitch = (chunksWide * tilesPerRow) * 8;
+    int pitch = (chunksWide * colsPerChunk) * 8;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
             int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
+                int idxComponentX = (chunkStartX * colsPerChunk + tilesSoFar) * 8 + k;
                 unsigned char srcPixel = src[idxComponentY * pitch + idxComponentX];
 
                 if (invertColors)
@@ -317,11 +317,11 @@ static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, colsPerChunk, rowsPerChunk);
     }
 }
 
-void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors)
+void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors)
 {
     int tileSize = bitDepth * 8; // number of bytes per tile
 
@@ -332,8 +332,8 @@ void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int row
 
     int tilesTall = (numTiles + tilesWide - 1) / tilesWide;
 
-    if (tilesWide % tilesPerRow != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
+    if (tilesWide % colsPerChunk != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
 
     if (tilesTall % rowsPerChunk != 0)
         FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
@@ -346,24 +346,24 @@ void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int row
     if (image->pixels == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
+    int chunksWide = tilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
 
     switch (bitDepth) {
     case 1:
-        ConvertFromTiles1Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertFromTiles1Bpp(buffer, image->pixels, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     case 4:
-        ConvertFromTiles4Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertFromTiles4Bpp(buffer, image->pixels, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     case 8:
-        ConvertFromTiles8Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertFromTiles8Bpp(buffer, image->pixels, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     }
 
     free(buffer);
 }
 
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack)
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack)
 {
     int fileSize;
     unsigned char *buffer = ReadWholeFile(path, &fileSize);
@@ -406,8 +406,8 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, 
     if (tilesTall < 0)
         tilesTall = (numTiles + tilesWide - 1) / tilesWide;
 
-    if (tilesWide % tilesPerRow != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
+    if (tilesWide % colsPerChunk != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
 
     if (tilesTall % rowsPerChunk != 0)
         FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
@@ -421,7 +421,7 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, 
     if (image->pixels == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
+    int chunksWide = tilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
 
     uint32_t key = 0;
     if (scanned)
@@ -441,11 +441,11 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, 
         switch (bitDepth)
         {
             case 4:
-                ConvertFromTiles4Bpp(imageData, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
+                ConvertFromTiles4Bpp(imageData, image->pixels, numTiles, chunksWide, colsPerChunk, rowsPerChunk,
                                      invertColors);
                 break;
             case 8:
-                ConvertFromTiles8Bpp(imageData, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
+                ConvertFromTiles8Bpp(imageData, image->pixels, numTiles, chunksWide, colsPerChunk, rowsPerChunk,
                                      invertColors);
                 break;
         }
@@ -455,7 +455,7 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, 
     return key;
 }
 
-void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors)
+void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors)
 {
     int tileSize = bitDepth * 8; // number of bytes per tile
 
@@ -468,8 +468,8 @@ void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int row
     int tilesWide = image->width / 8; // how many tiles wide the image is
     int tilesTall = image->height / 8; // how many tiles tall the image is
 
-    if (tilesWide % tilesPerRow != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
+    if (tilesWide % colsPerChunk != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
 
     if (tilesTall % rowsPerChunk != 0)
         FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
@@ -487,17 +487,17 @@ void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int row
     if (buffer == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
+    int chunksWide = tilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
 
     switch (bitDepth) {
     case 1:
-        ConvertToTiles1Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertToTiles1Bpp(image->pixels, buffer, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     case 4:
-        ConvertToTiles4Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertToTiles4Bpp(image->pixels, buffer, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     case 8:
-        ConvertToTiles8Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
+        ConvertToTiles8Bpp(image->pixels, buffer, numTiles, chunksWide, colsPerChunk, rowsPerChunk, invertColors);
         break;
     }
 
@@ -506,7 +506,7 @@ void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int row
     free(buffer);
 }
 
-void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image,
+void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
                    uint32_t mappingType, uint32_t key, bool wrongSize)
 {
@@ -526,8 +526,8 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int 
     int tilesWide = image->width / 8; // how many tiles wide the image is
     int tilesTall = image->height / 8; // how many tiles tall the image is
 
-    if (tilesWide % tilesPerRow != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
+    if (tilesWide % colsPerChunk != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
 
     if (tilesTall % rowsPerChunk != 0)
         FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
@@ -545,7 +545,7 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int 
     if (pixelBuffer == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
+    int chunksWide = tilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
 
     if (scanMode)
     {
@@ -564,11 +564,11 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int 
         switch (bitDepth)
         {
             case 4:
-                ConvertToTiles4Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
+                ConvertToTiles4Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, colsPerChunk, rowsPerChunk,
                                    invertColors);
                 break;
             case 8:
-                ConvertToTiles8Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
+                ConvertToTiles8Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, colsPerChunk, rowsPerChunk,
                                    invertColors);
                 break;
         }

--- a/gfx.c
+++ b/gfx.c
@@ -19,37 +19,37 @@
 
 #define DOWNCONVERT_BIT_DEPTH(x) ((x) / 8)
 
-static void AdvanceMetatilePosition(int *subTileX, int *subTileY, int *metatileX, int *metatileY, int metatilesWide, int metatileWidth, int metatileHeight)
+static void AdvanceTilePosition(int *tilesSoFar, int *rowsSoFar, int *chunkStartX, int *chunkStartY, int chunksWide, int tilesPerRow, int rowsPerChunk)
 {
-    (*subTileX)++;
-    if (*subTileX == metatileWidth) {
-        *subTileX = 0;
-        (*subTileY)++;
-        if (*subTileY == metatileHeight) {
-            *subTileY = 0;
-            (*metatileX)++;
-            if (*metatileX == metatilesWide) {
-                *metatileX = 0;
-                (*metatileY)++;
+    (*tilesSoFar)++;
+    if (*tilesSoFar == tilesPerRow) {
+        *tilesSoFar = 0;
+        (*rowsSoFar)++;
+        if (*rowsSoFar == rowsPerChunk) {
+            *rowsSoFar = 0;
+            (*chunkStartX)++;
+            if (*chunkStartX == chunksWide) {
+                *chunkStartX = 0;
+                (*chunkStartY)++;
             }
         }
     }
 }
 
-static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = metatilesWide * metatileWidth;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = chunksWide * tilesPerRow;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int destY = (metatileY * metatileHeight + subTileY) * 8 + j;
-            int destX = metatileX * metatileWidth + subTileX;
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponent2 = chunkStartX * tilesPerRow + tilesSoFar;
             unsigned char srcPixelOctet = *src++;
-            unsigned char *destPixelOctet = &dest[destY * pitch + destX];
+            unsigned char *destPixelOctet = &dest[idxComponent1 * pitch + idxComponent2];
 
             for (int k = 0; k < 8; k++) {
                 *destPixelOctet <<= 1;
@@ -58,24 +58,24 @@ static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int nu
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
-static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = (metatilesWide * metatileWidth) * 4;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = (chunksWide * tilesPerRow) * 4;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int destY = (metatileY * metatileHeight + subTileY) * 8 + j;
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int destX = (metatileX * metatileWidth + subTileX) * 4 + k;
+                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
                 unsigned char srcPixelPair = *src++;
                 unsigned char leftPixel = srcPixelPair & 0xF;
                 unsigned char rightPixel = srcPixelPair >> 4;
@@ -85,11 +85,11 @@ static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int nu
                     rightPixel = 15 - rightPixel;
                 }
 
-                dest[destY * pitch + destX] = (leftPixel << 4) | rightPixel;
+                dest[idxComponent1 * pitch + idxComponent2] = (leftPixel << 4) | rightPixel;
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
@@ -135,30 +135,30 @@ static uint32_t ConvertFromScanned4Bpp(unsigned char *src, unsigned char *dest, 
     return encValue;
 }
 
-static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = (metatilesWide * metatileWidth) * 8;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = (chunksWide * tilesPerRow) * 8;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int destY = (metatileY * metatileHeight + subTileY) * 8 + j;
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int destX = (metatileX * metatileWidth + subTileX) * 8 + k;
+                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
                 unsigned char srcPixel = *src++;
 
                 if (invertColors)
                     srcPixel = 255 - srcPixel;
 
-                dest[destY * pitch + destX] = srcPixel;
+                dest[idxComponent1 * pitch + idxComponent2] = srcPixel;
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
@@ -201,19 +201,19 @@ static uint32_t ConvertFromScanned8Bpp(unsigned char *src, unsigned char *dest, 
     return encValue;
 }
 
-static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = metatilesWide * metatileWidth;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = chunksWide * tilesPerRow;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int srcY = (metatileY * metatileHeight + subTileY) * 8 + j;
-            int srcX = metatileX * metatileWidth + subTileX;
-            unsigned char srcPixelOctet = src[srcY * pitch + srcX];
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponent2 = chunkStartX * tilesPerRow + tilesSoFar;
+            unsigned char srcPixelOctet = src[idxComponent1 * pitch + idxComponent2];
             unsigned char *destPixelOctet = dest++;
 
             for (int k = 0; k < 8; k++) {
@@ -223,25 +223,25 @@ static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
-static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = (metatilesWide * metatileWidth) * 4;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = (chunksWide * tilesPerRow) * 4;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int srcY = (metatileY * metatileHeight + subTileY) * 8 + j;
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int srcX = (metatileX * metatileWidth + subTileX) * 4 + k;
-                unsigned char srcPixelPair = src[srcY * pitch + srcX];
+                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
+                unsigned char srcPixelPair = src[idxComponent1 * pitch + idxComponent2];
                 unsigned char leftPixel = srcPixelPair >> 4;
                 unsigned char rightPixel = srcPixelPair & 0xF;
 
@@ -254,7 +254,7 @@ static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
@@ -294,21 +294,21 @@ static void ConvertToScanned4Bpp(unsigned char *src, unsigned char *dest, int fi
     }
 }
 
-static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int metatilesWide, int metatileWidth, int metatileHeight, bool invertColors)
+static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numTiles, int chunksWide, int tilesPerRow, int rowsPerChunk, bool invertColors)
 {
-    int subTileX = 0;
-    int subTileY = 0;
-    int metatileX = 0;
-    int metatileY = 0;
-    int pitch = (metatilesWide * metatileWidth) * 8;
+    int tilesSoFar = 0;
+    int rowsSoFar = 0;
+    int chunkStartX = 0;
+    int chunkStartY = 0;
+    int pitch = (chunksWide * tilesPerRow) * 8;
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int srcY = (metatileY * metatileHeight + subTileY) * 8 + j;
+            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int srcX = (metatileX * metatileWidth + subTileX) * 8 + k;
-                unsigned char srcPixel = src[srcY * pitch + srcX];
+                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
+                unsigned char srcPixel = src[idxComponent1 * pitch + idxComponent2];
 
                 if (invertColors)
                     srcPixel = 255 - srcPixel;
@@ -317,53 +317,53 @@ static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numT
             }
         }
 
-        AdvanceMetatilePosition(&subTileX, &subTileY, &metatileX, &metatileY, metatilesWide, metatileWidth, metatileHeight);
+        AdvanceTilePosition(&tilesSoFar, &rowsSoFar, &chunkStartX, &chunkStartY, chunksWide, tilesPerRow, rowsPerChunk);
     }
 }
 
-void ReadImage(char *path, int tilesWidth, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors)
+void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors)
 {
-    int tileSize = bitDepth * 8;
+    int tileSize = bitDepth * 8; // number of bytes per tile
 
     int fileSize;
     unsigned char *buffer = ReadWholeFile(path, &fileSize);
 
     int numTiles = fileSize / tileSize;
 
-    int tilesHeight = (numTiles + tilesWidth - 1) / tilesWidth;
+    int tilesTall = (numTiles + tilesWide - 1) / tilesWide;
 
-    if (tilesWidth % metatileWidth != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified metatile width (%d)", tilesWidth, metatileWidth);
+    if (tilesWide % tilesPerRow != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
 
-    if (tilesHeight % metatileHeight != 0)
-        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified metatile height (%d)", tilesHeight, metatileHeight);
+    if (tilesTall % rowsPerChunk != 0)
+        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
 
-    image->width = tilesWidth * 8;
-    image->height = tilesHeight * 8;
+    image->width = tilesWide * 8;
+    image->height = tilesTall * 8;
     image->bitDepth = bitDepth;
-    image->pixels = calloc(tilesWidth * tilesHeight, tileSize);
+    image->pixels = calloc(tilesWide * tilesTall, tileSize);
 
     if (image->pixels == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int metatilesWide = tilesWidth / metatileWidth;
+    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
 
     switch (bitDepth) {
     case 1:
-        ConvertFromTiles1Bpp(buffer, image->pixels, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertFromTiles1Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     case 4:
-        ConvertFromTiles4Bpp(buffer, image->pixels, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertFromTiles4Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     case 8:
-        ConvertFromTiles8Bpp(buffer, image->pixels, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertFromTiles8Bpp(buffer, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     }
 
     free(buffer);
 }
 
-uint32_t ReadNtrImage(char *path, int tilesWidth, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors, bool scanFrontToBack)
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack)
 {
     int fileSize;
     unsigned char *buffer = ReadWholeFile(path, &fileSize);
@@ -391,37 +391,37 @@ uint32_t ReadNtrImage(char *path, int tilesWidth, int bitDepth, int metatileWidt
 
     bool scanned = charHeader[0x14];
 
-    int tileSize = bitDepth * 8;
+    int tileSize = bitDepth * 8; // number of bytes per tile
 
-    if (tilesWidth == 0) {
-        tilesWidth = ReadS16(charHeader, 0xA);
-        if (tilesWidth < 0) {
-            tilesWidth = 1;
+    if (tilesWide == 0) {
+        tilesWide = ReadS16(charHeader, 0xA);
+        if (tilesWide < 0) {
+            tilesWide = 1;
         }
     }
 
     int numTiles = ReadS32(charHeader, 0x18) / (64 / (8 / bitDepth));
 
-    int tilesHeight = ReadS16(charHeader, 0x8);
-    if (tilesHeight < 0)
-        tilesHeight = (numTiles + tilesWidth - 1) / tilesWidth;
+    int tilesTall = ReadS16(charHeader, 0x8);
+    if (tilesTall < 0)
+        tilesTall = (numTiles + tilesWide - 1) / tilesWide;
 
-    if (tilesWidth % metatileWidth != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified metatile width (%d)", tilesWidth, metatileWidth);
+    if (tilesWide % tilesPerRow != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
 
-    if (tilesHeight % metatileHeight != 0)
-        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified metatile height (%d)", tilesHeight, metatileHeight);
+    if (tilesTall % rowsPerChunk != 0)
+        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
 
 
-    image->width = tilesWidth * 8;
-    image->height = tilesHeight * 8;
+    image->width = tilesWide * 8;
+    image->height = tilesTall * 8;
     image->bitDepth = bitDepth;
-    image->pixels = calloc(tilesWidth * tilesHeight, tileSize);
+    image->pixels = calloc(tilesWide * tilesTall, tileSize);
 
     if (image->pixels == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int metatilesWide = tilesWidth / metatileWidth;
+    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
 
     uint32_t key = 0;
     if (scanned)
@@ -441,11 +441,11 @@ uint32_t ReadNtrImage(char *path, int tilesWidth, int bitDepth, int metatileWidt
         switch (bitDepth)
         {
             case 4:
-                ConvertFromTiles4Bpp(imageData, image->pixels, numTiles, metatilesWide, metatileWidth, metatileHeight,
+                ConvertFromTiles4Bpp(imageData, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
                                      invertColors);
                 break;
             case 8:
-                ConvertFromTiles8Bpp(imageData, image->pixels, numTiles, metatilesWide, metatileWidth, metatileHeight,
+                ConvertFromTiles8Bpp(imageData, image->pixels, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
                                      invertColors);
                 break;
         }
@@ -455,9 +455,9 @@ uint32_t ReadNtrImage(char *path, int tilesWidth, int bitDepth, int metatileWidt
     return key;
 }
 
-void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors)
+void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors)
 {
-    int tileSize = bitDepth * 8;
+    int tileSize = bitDepth * 8; // number of bytes per tile
 
     if (image->width % 8 != 0)
         FATAL_ERROR("The width in pixels (%d) isn't a multiple of 8.\n", image->width);
@@ -465,16 +465,16 @@ void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int m
     if (image->height % 8 != 0)
         FATAL_ERROR("The height in pixels (%d) isn't a multiple of 8.\n", image->height);
 
-    int tilesWidth = image->width / 8;
-    int tilesHeight = image->height / 8;
+    int tilesWide = image->width / 8; // how many tiles wide the image is
+    int tilesTall = image->height / 8; // how many tiles tall the image is
 
-    if (tilesWidth % metatileWidth != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified metatile width (%d)", tilesWidth, metatileWidth);
+    if (tilesWide % tilesPerRow != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
 
-    if (tilesHeight % metatileHeight != 0)
-        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified metatile height (%d)", tilesHeight, metatileHeight);
+    if (tilesTall % rowsPerChunk != 0)
+        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
 
-    int maxNumTiles = tilesWidth * tilesHeight;
+    int maxNumTiles = tilesWide * tilesTall;
 
     if (numTiles == 0)
         numTiles = maxNumTiles;
@@ -487,17 +487,17 @@ void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int m
     if (buffer == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int metatilesWide = tilesWidth / metatileWidth;
+    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
 
     switch (bitDepth) {
     case 1:
-        ConvertToTiles1Bpp(image->pixels, buffer, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertToTiles1Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     case 4:
-        ConvertToTiles4Bpp(image->pixels, buffer, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertToTiles4Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     case 8:
-        ConvertToTiles8Bpp(image->pixels, buffer, numTiles, metatilesWide, metatileWidth, metatileHeight, invertColors);
+        ConvertToTiles8Bpp(image->pixels, buffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk, invertColors);
         break;
     }
 
@@ -506,7 +506,7 @@ void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int m
     free(buffer);
 }
 
-void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image,
+void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
                    uint32_t mappingType, uint32_t key, bool wrongSize)
 {
@@ -515,7 +515,7 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
     if (fp == NULL)
         FATAL_ERROR("Failed to open \"%s\" for writing.\n", path);
 
-    int tileSize = bitDepth * 8;
+    int tileSize = bitDepth * 8; // number of bytes per tile
 
     if (image->width % 8 != 0)
         FATAL_ERROR("The width in pixels (%d) isn't a multiple of 8.\n", image->width);
@@ -523,16 +523,16 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
     if (image->height % 8 != 0)
         FATAL_ERROR("The height in pixels (%d) isn't a multiple of 8.\n", image->height);
 
-    int tilesWidth = image->width / 8;
-    int tilesHeight = image->height / 8;
+    int tilesWide = image->width / 8; // how many tiles wide the image is
+    int tilesTall = image->height / 8; // how many tiles tall the image is
 
-    if (tilesWidth % metatileWidth != 0)
-        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified metatile width (%d)", tilesWidth, metatileWidth);
+    if (tilesWide % tilesPerRow != 0)
+        FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, tilesPerRow);
 
-    if (tilesHeight % metatileHeight != 0)
-        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified metatile height (%d)", tilesHeight, metatileHeight);
+    if (tilesTall % rowsPerChunk != 0)
+        FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
 
-    int maxNumTiles = tilesWidth * tilesHeight;
+    int maxNumTiles = tilesWide * tilesTall;
 
     if (numTiles == 0)
         numTiles = maxNumTiles;
@@ -545,7 +545,7 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
     if (pixelBuffer == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int metatilesWide = tilesWidth / metatileWidth;
+    int chunksWide = tilesWide / tilesPerRow; // how many chunks side-by-side are needed for the full width of the image
 
     if (scanMode)
     {
@@ -564,11 +564,11 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
         switch (bitDepth)
         {
             case 4:
-                ConvertToTiles4Bpp(image->pixels, pixelBuffer, numTiles, metatilesWide, metatileWidth, metatileHeight,
+                ConvertToTiles4Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
                                    invertColors);
                 break;
             case 8:
-                ConvertToTiles8Bpp(image->pixels, pixelBuffer, numTiles, metatilesWide, metatileWidth, metatileHeight,
+                ConvertToTiles8Bpp(image->pixels, pixelBuffer, numTiles, chunksWide, tilesPerRow, rowsPerChunk,
                                    invertColors);
                 break;
         }
@@ -586,11 +586,11 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
 
     if (!clobberSize)
     {
-        charHeader[8] = tilesHeight & 0xFF;
-        charHeader[9] = (tilesHeight >> 8) & 0xFF;
+        charHeader[8] = tilesTall & 0xFF;
+        charHeader[9] = (tilesTall >> 8) & 0xFF;
 
-        charHeader[10] = tilesWidth & 0xFF;
-        charHeader[11] = (tilesWidth >> 8) & 0xFF;
+        charHeader[10] = tilesWide & 0xFF;
+        charHeader[11] = (tilesWide >> 8) & 0xFF;
     }
     else
     {
@@ -655,11 +655,11 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, in
     {
         unsigned char sopcBuffer[0x10] = { 0x53, 0x4F, 0x50, 0x43, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-        sopcBuffer[12] = tilesWidth & 0xFF;
-        sopcBuffer[13] = (tilesWidth >> 8) & 0xFF;
+        sopcBuffer[12] = tilesWide & 0xFF;
+        sopcBuffer[13] = (tilesWide >> 8) & 0xFF;
 
-        sopcBuffer[14] = tilesHeight & 0xFF;
-        sopcBuffer[15] = (tilesHeight >> 8) & 0xFF;
+        sopcBuffer[14] = tilesTall & 0xFF;
+        sopcBuffer[15] = (tilesTall >> 8) & 0xFF;
 
         fwrite(sopcBuffer, 1, 0x10, fp);
     }

--- a/gfx.c
+++ b/gfx.c
@@ -46,10 +46,10 @@ static void ConvertFromTiles1Bpp(unsigned char *src, unsigned char *dest, int nu
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
-            int idxComponent2 = chunkStartX * tilesPerRow + tilesSoFar;
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentX = chunkStartX * tilesPerRow + tilesSoFar;
             unsigned char srcPixelOctet = *src++;
-            unsigned char *destPixelOctet = &dest[idxComponent1 * pitch + idxComponent2];
+            unsigned char *destPixelOctet = &dest[idxComponentY * pitch + idxComponentX];
 
             for (int k = 0; k < 8; k++) {
                 *destPixelOctet <<= 1;
@@ -72,10 +72,10 @@ static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int nu
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
+                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
                 unsigned char srcPixelPair = *src++;
                 unsigned char leftPixel = srcPixelPair & 0xF;
                 unsigned char rightPixel = srcPixelPair >> 4;
@@ -85,7 +85,7 @@ static void ConvertFromTiles4Bpp(unsigned char *src, unsigned char *dest, int nu
                     rightPixel = 15 - rightPixel;
                 }
 
-                dest[idxComponent1 * pitch + idxComponent2] = (leftPixel << 4) | rightPixel;
+                dest[idxComponentY * pitch + idxComponentX] = (leftPixel << 4) | rightPixel;
             }
         }
 
@@ -145,16 +145,16 @@ static void ConvertFromTiles8Bpp(unsigned char *src, unsigned char *dest, int nu
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
+                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
                 unsigned char srcPixel = *src++;
 
                 if (invertColors)
                     srcPixel = 255 - srcPixel;
 
-                dest[idxComponent1 * pitch + idxComponent2] = srcPixel;
+                dest[idxComponentY * pitch + idxComponentX] = srcPixel;
             }
         }
 
@@ -211,9 +211,9 @@ static void ConvertToTiles1Bpp(unsigned char *src, unsigned char *dest, int numT
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
-            int idxComponent2 = chunkStartX * tilesPerRow + tilesSoFar;
-            unsigned char srcPixelOctet = src[idxComponent1 * pitch + idxComponent2];
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentX = chunkStartX * tilesPerRow + tilesSoFar;
+            unsigned char srcPixelOctet = src[idxComponentY * pitch + idxComponentX];
             unsigned char *destPixelOctet = dest++;
 
             for (int k = 0; k < 8; k++) {
@@ -237,11 +237,11 @@ static void ConvertToTiles4Bpp(unsigned char *src, unsigned char *dest, int numT
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 4; k++) {
-                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
-                unsigned char srcPixelPair = src[idxComponent1 * pitch + idxComponent2];
+                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 4 + k;
+                unsigned char srcPixelPair = src[idxComponentY * pitch + idxComponentX];
                 unsigned char leftPixel = srcPixelPair >> 4;
                 unsigned char rightPixel = srcPixelPair & 0xF;
 
@@ -304,11 +304,11 @@ static void ConvertToTiles8Bpp(unsigned char *src, unsigned char *dest, int numT
 
     for (int i = 0; i < numTiles; i++) {
         for (int j = 0; j < 8; j++) {
-            int idxComponent1 = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
+            int idxComponentY = (chunkStartY * rowsPerChunk + rowsSoFar) * 8 + j;
 
             for (int k = 0; k < 8; k++) {
-                int idxComponent2 = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
-                unsigned char srcPixel = src[idxComponent1 * pitch + idxComponent2];
+                int idxComponentX = (chunkStartX * tilesPerRow + tilesSoFar) * 8 + k;
+                unsigned char srcPixel = src[idxComponentY * pitch + idxComponentX];
 
                 if (invertColors)
                     srcPixel = 255 - srcPixel;

--- a/gfx.h
+++ b/gfx.h
@@ -50,10 +50,10 @@ struct Image {
 	bool hasTransparency;
 };
 
-void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors);
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
-void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors);
-void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image,
+void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
+void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
+void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
                    uint32_t mappingType, uint32_t key, bool wrongSize);
 void FreeImage(struct Image *image);

--- a/gfx.h
+++ b/gfx.h
@@ -23,16 +23,37 @@ struct Image {
 	int width;
 	int height;
 	int bitDepth;
+    /**
+     * Pseudocode for converting index in pixels to coordinates in image is as follows
+     *      (where (0, 0) is the top left corner with the format (x, y) ):
+     * if (bitDepth == 4)
+     *      for (int i = 0; i < width * height / 2; i++)
+     *          xCoord = i % <WIDTH OF IMAGE>
+     *          yCoord = i / <WIDTH OF IMAGE>
+     *
+     *          leftPixel = pixels[i] & 0xF
+     *          rightPixel = pixels[i] >> 4)
+     *
+     *          leftPixel coordinates: (xCoord, yCoord)
+     *          rightPixel coordinates: (xCoord + 1, yCoord)
+     * else if (bitDepth == 8)
+     *      for (int i = 0; i < width * height; i++)
+     *          xCoord = i % <WIDTH OF IMAGE>
+     *          yCoord = i / <WIDTH OF IMAGE>
+     *
+     *          pixel = pixels[i]
+     *          pixel coordinates: (xCoord, yCoord)
+     */
 	unsigned char *pixels;
 	bool hasPalette;
 	struct Palette palette;
 	bool hasTransparency;
 };
 
-void ReadImage(char *path, int tilesWidth, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors);
-uint32_t ReadNtrImage(char *path, int tilesWidth, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors, bool scanFrontToBack);
-void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors);
-void WriteNtrImage(char *path, int numTiles, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image,
+void ReadImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors);
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
+void WriteImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image, bool invertColors);
+void WriteNtrImage(char *path, int numTiles, int bitDepth, int tilesPerRow, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
                    uint32_t mappingType, uint32_t key, bool wrongSize);
 void FreeImage(struct Image *image);

--- a/options.h
+++ b/options.h
@@ -11,23 +11,23 @@ struct GbaToPngOptions {
     int bitDepth;
     bool hasTransparency;
     int width;
-    int metatileWidth;
-    int metatileHeight;
+    int tilesPerRow;
+    int rowsPerChunk;
     int palIndex;
 };
 
 struct PngToGbaOptions {
     int numTiles;
     int bitDepth;
-    int metatileWidth;
-    int metatileHeight;
+    int tilesPerRow;
+    int rowsPerChunk;
 };
 
 struct PngToNtrOptions {
     int numTiles;
     int bitDepth;
-    int metatileWidth;
-    int metatileHeight;
+    int tilesPerRow;
+    int rowsPerChunk;
     bool clobberSize;
     bool byteOrder;
     bool version101;
@@ -44,8 +44,8 @@ struct NtrToPngOptions {
     int bitDepth;
     bool hasTransparency;
     int width;
-    int metatileWidth;
-    int metatileHeight;
+    int tilesPerRow;
+    int rowsPerChunk;
     int palIndex;
     bool scanFrontToBack;
     bool handleEmpty;

--- a/options.h
+++ b/options.h
@@ -11,7 +11,7 @@ struct GbaToPngOptions {
     int bitDepth;
     bool hasTransparency;
     int width;
-    int tilesPerRow;
+    int colsPerChunk;
     int rowsPerChunk;
     int palIndex;
 };
@@ -19,14 +19,14 @@ struct GbaToPngOptions {
 struct PngToGbaOptions {
     int numTiles;
     int bitDepth;
-    int tilesPerRow;
+    int colsPerChunk;
     int rowsPerChunk;
 };
 
 struct PngToNtrOptions {
     int numTiles;
     int bitDepth;
-    int tilesPerRow;
+    int colsPerChunk;
     int rowsPerChunk;
     bool clobberSize;
     bool byteOrder;
@@ -44,7 +44,7 @@ struct NtrToPngOptions {
     int bitDepth;
     bool hasTransparency;
     int width;
-    int tilesPerRow;
+    int colsPerChunk;
     int rowsPerChunk;
     int palIndex;
     bool scanFrontToBack;


### PR DESCRIPTION
The main point of the changes introduced by this PR is to improve the readability and intuitiveness of the NCGR processing related code. After some testing, I was able to verify what exactly the variables currently known as "metatileWidth" and "metatileHeight" do. 

The "default" behavior, as seen below, is when those two variables are set to 1:

https://github.com/red031000/nitrogfx/assets/7987859/599d478b-7d5e-4660-bf55-5decd1ad2008

Modifying the metatileWidth value seemed to have no effect on its own initially, other than the program exiting when the width of the image was not evenly divisible by it. Starting to play with metatileHeight while leaving metatileWidth as 1 showed it would insert a number of tiles equal to metatileHeight along the vertical axis before returning to the top of the image in the next column, unless the width of the image has been filled and it advanced down a number of rows equal to metatileHeight as seen here (metatileHeight of 2 was used):

https://github.com/red031000/nitrogfx/assets/7987859/71e1130b-8cfd-4634-808f-fea317f208f8

Once you start modifying both, the behavior of metatileWidth becomes clear (metatileHeight of 2 and metatileWidth of 4 were used).

https://github.com/red031000/nitrogfx/assets/7987859/467b0bab-8be3-4b08-b93a-ea21aacb0a60

The variable renaming these changes introduce will introduce the concept of "chunks" of NCGR tiled image data, where a chunk is defined by the number of tiles in each row (~`tilesPerRow`~ `colsPerChunk`), and how many rows tall a chunk is (`rowsPerChunk`).

*It should be noted the variable name `tilesPerCol` was not used to avoid confusion as to whether the code is referring to the number of tiles per column in the image as opposed to in a chunk.*

Refactoring is as follows:
* `AdvanceMetatilePosition` -> `AdvanceTilePosition`
  * this also includes changes to the variable names passed to it for the sake of readability.
* `metatilesWide` -> `chunksWide`
* `metatileWidth` -> ~`tilesPerRow`~ -> `colsPerChunk`
* `metatileHeight` -> `rowsPerChunk`
* `tilesWidth` -> `tilesWide`
* `tilesHeight` -> `tilesTall`
**Note:** following issues raised in response to PR, tilesPerRow has been crossed out and replaced with colsPerChunk.

In the ConvertToTiles#Bpp and ConvertFromTiles#Bpp methods, the following variables were renamed to avoid confusion since these are not the actual values resulting in pixel position in a 2D grid of pixels when the image is processed, but simply components of it.
* `destY` -> ~`idxComponent1`~ -> `idxComponentY`
* `destX` -> ~`idxComponent2`~ -> `idxComponentX`
* `srcY` -> ~`idxComponent1`~ -> `idxComponentY`
* `srcX` -> ~`idxComponent2`~ -> `idxComponentX`
**Note:** following issues raised in response to PR, the above listed variables have been modified and the original modified names have been crossed out and new names added. 


In terms of CMD args, ~`-tpr` (tiles per row)~ `-cpc` (columns per chunk) is introduced as an alternative to `-mwidth` and `-rpc` (rows per chunk) is introduced as an alternative to `-mheight`. The original argument strings are still valid to avoid breaking existing workflows.