### PR TITLE
Add support for building NCER files with OAM count > 1, support for VRAM transfer data

### DIFF
--- a/json.c
+++ b/json.c
@@ -641,6 +641,14 @@ void FreeNCERCell(struct JsonToCellOptions *options)
         }
         free(options->labels);
     }
+    if (options->vramTransferEnabled)
+    {
+        for (int j = 0; j < options->cellCount; j++)
+        {
+            free(options->transferData[j]);
+        }
+        free(options->transferData);
+    }
     free(options->cells);
     free(options);
 }

--- a/options.h
+++ b/options.h
@@ -51,6 +51,11 @@ struct NtrToPngOptions {
     bool handleEmpty;
 };
 
+struct CellVramTransferData {
+    int sourceDataOffset;
+    int size;
+};
+
 struct Attr0 {
     int YCoordinate;
     bool Rotation;
@@ -100,12 +105,12 @@ struct Cell {
 struct JsonToCellOptions {
     bool labelEnabled;
     bool extended;
-    bool partitionEnabled;
+    bool vramTransferEnabled;
     int mappingType;
     int cellCount;
     struct Cell **cells;
-    int *partitionData;
-    int partitionCount;
+    int vramTransferMaxSize;
+    struct CellVramTransferData **transferData;
     char **labels;
     int labelCount;
 };

--- a/options.h
+++ b/options.h
@@ -100,9 +100,12 @@ struct Cell {
 struct JsonToCellOptions {
     bool labelEnabled;
     bool extended;
+    bool partitionEnabled;
     int mappingType;
     int cellCount;
     struct Cell **cells;
+    int *partitionData;
+    int partitionCount;
     char **labels;
     int labelCount;
 };


### PR DESCRIPTION
- the KBEC size is currently calculated using `options->cellCount * (options->extended ? 0x16 : 0xe)`, which assumes each cell contains only 1 OAM (OAM size = 0x06, bank size = 0x10 or 0x08), ensure we calculate the right size by adding 0x06 for each OAM in the cell
- the NCER spec defines partition data after the OAM data which is only present if KBECHeader[20:24] is non-zero, some NCER in pl_batt_obj use this so adding preliminary support for it

I don't really understand the purpose or layout of the partition data (spec I looked at http://llref.emutalk.net/docs/?file=xml/ncer.xml is very sparse on it) so I just dump it as an array of ints, if anyone understands what it's used for maybe it should be converted into a struct before this is merged.