### PR TITLE
fix incorrect bounds checking for CEBK block

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -926,7 +926,7 @@ void ReadNtrCell_CEBK(unsigned char * restrict data, unsigned int blockOffset, u
     for (int i = 0; i < options->cellCount; i++)
     {
         int offset = blockOffset + 0x20 + (i * celSize);
-        if (offset + celSize > blockSize) {
+        if (offset + celSize > blockOffset + blockSize) {
             FATAL_ERROR("corrupted CEBK block");
         }
         options->cells[i] = malloc(sizeof(struct Cell));


### PR DESCRIPTION
in `offset + celSize > blockSize`, offset is relative to the start of the NCER file, but blockSize is relative to the start of the CEBK block. need to make both relative to the start of the file by adding `blockOffset` to the right-hand side, otherwise very small NCER files will incorrectly hit this error