### PR TITLE
Introduce alternative NANR decompile/recompile routines

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -66,5 +66,7 @@ void WriteNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrScreen(char *path, struct JsonToScreenOptions *options);
 void ReadNtrAnimation(char *path, struct JsonToAnimationOptions *options);
 void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options);
+void ReadNtrAnimation_New(char *path, struct JsonToAnimationOptions_New *options);
+void WriteNtrAnimation_New(char *path, struct JsonToAnimationOptions_New *options);
 
 #endif // GFX_H

--- a/json.c
+++ b/json.c
@@ -545,7 +545,9 @@ struct JsonToAnimationOptions_New *ParseNANRJson_New(char *path)
     cJSON_ArrayForEach(animationResult, animationResults)
     {
         cJSON *dataType = cJSON_GetObjectItemCaseSensitive(animationResult, "dataType");
+        cJSON *padded = cJSON_GetObjectItemCaseSensitive(animationResult, "padded");
         options->animationResults[i]->dataType = GetInt(dataType);
+        options->animationResults[i]->padded = GetBool(padded);
 
         switch (options->animationResults[i]->dataType)
         {
@@ -787,6 +789,7 @@ char *GetNANRJson_New(struct JsonToAnimationOptions_New *options)
     {
         cJSON *animationResult = cJSON_CreateObject();
         cJSON_AddNumberToObject(animationResult, "dataType", options->animationResults[i]->dataType);
+        cJSON_AddBoolToObject(animationResult, "padded", options->animationResults[i]->padded);
         switch(options->animationResults[i]->dataType)
         {
             case 0: //index
@@ -884,11 +887,14 @@ void FreeNANRAnimation_New(struct JsonToAnimationOptions_New *options)
     {
         for (int j = 0; j < options->sequenceData[i]->frameCount; j++)
         {
-            free(options->animationResults[i]);
             free(options->sequenceData[i]->frameData[j]);
         }
         free(options->sequenceData[i]->frameData);
         free(options->sequenceData[i]);
+    }
+    for (int i = 0; i < options->resultCount; i++)
+    {
+        free(options->animationResults[i]);
     }
     if (options->labelEnabled)
     {

--- a/json.c
+++ b/json.c
@@ -707,7 +707,6 @@ char *GetNANRJson(struct JsonToAnimationOptions *options)
     for (int i = 0; i < options->resultCount; i++)
     {
         cJSON *animationResult = cJSON_CreateObject();
-        cJSON_AddNumberToObject(animationResult, "dataType", options->animationResults[i]->dataType);
         cJSON_AddNumberToObject(animationResult, "resultType", options->animationResults[i]->resultType);
 
         switch (options->animationResults[i]->resultType)
@@ -787,6 +786,7 @@ char *GetNANRJson_New(struct JsonToAnimationOptions_New *options)
     for (int i = 0; i < options->resultCount; i++)
     {
         cJSON *animationResult = cJSON_CreateObject();
+        cJSON_AddNumberToObject(animationResult, "dataType", options->animationResults[i]->dataType);
         switch(options->animationResults[i]->dataType)
         {
             case 0: //index

--- a/json.c
+++ b/json.c
@@ -544,7 +544,7 @@ struct JsonToAnimationOptions_New *ParseNANRJson_New(char *path)
     i = 0;
     cJSON_ArrayForEach(animationResult, animationResults)
     {
-        cJSON *dataType = cJSON_GetObjectItemCaseSensitive(json, "dataType");
+        cJSON *dataType = cJSON_GetObjectItemCaseSensitive(animationResult, "dataType");
         options->animationResults[i]->dataType = GetInt(dataType);
 
         switch (options->animationResults[i]->dataType)
@@ -707,6 +707,7 @@ char *GetNANRJson(struct JsonToAnimationOptions *options)
     for (int i = 0; i < options->resultCount; i++)
     {
         cJSON *animationResult = cJSON_CreateObject();
+        cJSON_AddNumberToObject(animationResult, "dataType", options->animationResults[i]->dataType);
         cJSON_AddNumberToObject(animationResult, "resultType", options->animationResults[i]->resultType);
 
         switch (options->animationResults[i]->resultType)

--- a/json.c
+++ b/json.c
@@ -523,13 +523,72 @@ struct JsonToAnimationOptions_New *ParseNANRJson_New(char *path)
 
     cJSON *sequenceCount = cJSON_GetObjectItemCaseSensitive(json, "sequenceCount");
     cJSON *frameCount = cJSON_GetObjectItemCaseSensitive(json, "frameCount");
+    cJSON *resultCount = cJSON_GetObjectItemCaseSensitive(json, "resultCount");
 
     options->sequenceCount = GetInt(sequenceCount);
     options->frameCount = GetInt(frameCount);
+    options->resultCount = GetInt(resultCount);
 
     options->sequenceData = malloc(sizeof(struct SequenceData *) * options->sequenceCount);
+    options->animationResults = malloc(sizeof(struct AnimationResults_New *) * options->resultCount);
 
     int i;
+    for (i = 0; i < options->resultCount; i++)
+    {
+        options->animationResults[i] = malloc(sizeof(struct AnimationResults_New));
+    }
+
+    cJSON *animationResult = NULL;
+    cJSON *animationResults = cJSON_GetObjectItemCaseSensitive(json, "animationResults");
+
+    i = 0;
+    cJSON_ArrayForEach(animationResult, animationResults)
+    {
+        cJSON *dataType = cJSON_GetObjectItemCaseSensitive(json, "dataType");
+        options->animationResults[i]->dataType = GetInt(dataType);
+
+        switch (options->animationResults[i]->dataType)
+        {
+            case 0: { //index
+                cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
+                options->animationResults[i]->index = GetInt(index);
+                break;
+            }
+
+            case 1: { //SRT
+                cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
+                cJSON *rotation = cJSON_GetObjectItemCaseSensitive(animationResult, "rotation");
+                cJSON *scaleX = cJSON_GetObjectItemCaseSensitive(animationResult, "scaleX");
+                cJSON *scaleY = cJSON_GetObjectItemCaseSensitive(animationResult, "scaleY");
+                cJSON *positionX = cJSON_GetObjectItemCaseSensitive(animationResult, "positionX");
+                cJSON *positionY = cJSON_GetObjectItemCaseSensitive(animationResult, "positionY");
+
+                options->animationResults[i]->dataSrt.index = GetInt(index);
+                options->animationResults[i]->dataSrt.rotation = GetInt(rotation);
+                options->animationResults[i]->dataSrt.scaleX = GetInt(scaleX);
+                options->animationResults[i]->dataSrt.scaleY = GetInt(scaleY);
+                options->animationResults[i]->dataSrt.positionX = GetInt(positionX);
+                options->animationResults[i]->dataSrt.positionY = GetInt(positionY);
+                break;
+            }
+
+            case 2: { //T
+                cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
+                //cJSON *rotation = cJSON_GetObjectItemCaseSensitive(animationResult, "rotation");
+                cJSON *positionX = cJSON_GetObjectItemCaseSensitive(animationResult, "positionX");
+                cJSON *positionY = cJSON_GetObjectItemCaseSensitive(animationResult, "positionY");
+
+                options->animationResults[i]->dataT.index = GetInt(index);
+                //options->animationResults[i]->dataSrt.rotation = GetInt(rotation);
+                options->animationResults[i]->dataT.positionX = GetInt(positionX);
+                options->animationResults[i]->dataT.positionY = GetInt(positionY);
+                break;
+            }
+        }
+
+        i++;
+    }
+
     for (i = 0; i < options->sequenceCount; i++)
     {
         options->sequenceData[i] = malloc(sizeof(struct SequenceData));
@@ -573,49 +632,10 @@ struct JsonToAnimationOptions_New *ParseNANRJson_New(char *path)
                 FATAL_ERROR("Sequence frame count is incorrect.\n");
 
             cJSON *frameDelay = cJSON_GetObjectItemCaseSensitive(frame, "frameDelay");
-            cJSON *animationResult = cJSON_GetObjectItemCaseSensitive(frame, "animationResult");
+            cJSON *resultId = cJSON_GetObjectItemCaseSensitive(frame, "resultId");
 
             options->sequenceData[i]->frameData[j]->frameDelay = GetInt(frameDelay);
-            options->sequenceData[i]->frameData[j]->resultData = malloc(sizeof(struct AnimationResults));
-
-            switch (options->sequenceData[i]->dataType)
-            {
-                case 0: { //index
-                    cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
-                    options->sequenceData[i]->frameData[j]->resultData->index = GetInt(index);
-                    break;
-                }
-
-                case 1: { //SRT
-                    cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
-                    cJSON *rotation = cJSON_GetObjectItemCaseSensitive(animationResult, "rotation");
-                    cJSON *scaleX = cJSON_GetObjectItemCaseSensitive(animationResult, "scaleX");
-                    cJSON *scaleY = cJSON_GetObjectItemCaseSensitive(animationResult, "scaleY");
-                    cJSON *positionX = cJSON_GetObjectItemCaseSensitive(animationResult, "positionX");
-                    cJSON *positionY = cJSON_GetObjectItemCaseSensitive(animationResult, "positionY");
-
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.index = GetInt(index);
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.rotation = GetInt(rotation);
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.scaleX = GetInt(scaleX);
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.scaleY = GetInt(scaleY);
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.positionX = GetInt(positionX);
-                    options->sequenceData[i]->frameData[j]->resultData->dataSrt.positionY = GetInt(positionY);
-                    break;
-                }
-
-                case 2: { //T
-                    cJSON *index = cJSON_GetObjectItemCaseSensitive(animationResult, "index");
-                    //cJSON *rotation = cJSON_GetObjectItemCaseSensitive(animationResult, "rotation");
-                    cJSON *positionX = cJSON_GetObjectItemCaseSensitive(animationResult, "positionX");
-                    cJSON *positionY = cJSON_GetObjectItemCaseSensitive(animationResult, "positionY");
-
-                    options->sequenceData[i]->frameData[j]->resultData->dataT.index = GetInt(index);
-                    //options->sequenceData[i]->frameData[j]->resultData->dataSrt.rotation = GetInt(rotation);
-                    options->sequenceData[i]->frameData[j]->resultData->dataT.positionX = GetInt(positionX);
-                    options->sequenceData[i]->frameData[j]->resultData->dataT.positionY = GetInt(positionY);
-                    break;
-                }
-            }
+            options->sequenceData[i]->frameData[j]->resultId = GetInt(resultId);
 
             j++;
         }
@@ -736,6 +756,7 @@ char *GetNANRJson_New(struct JsonToAnimationOptions_New *options)
     cJSON_AddBoolToObject(nanr, "labelEnabled", options->labelEnabled);
     cJSON_AddNumberToObject(nanr, "sequenceCount", options->sequenceCount);
     cJSON_AddNumberToObject(nanr, "frameCount", options->frameCount);
+    cJSON_AddNumberToObject(nanr, "resultCount", options->resultCount);
 
     cJSON *sequences = cJSON_AddArrayToObject(nanr, "sequences");
 
@@ -754,36 +775,42 @@ char *GetNANRJson_New(struct JsonToAnimationOptions_New *options)
         {
             cJSON *frame = cJSON_CreateObject();
             cJSON_AddNumberToObject(frame, "frameDelay", options->sequenceData[i]->frameData[j]->frameDelay);
-
-            cJSON *animationResult = cJSON_AddObjectToObject(frame, "animationResult");
-            switch(options->sequenceData[i]->dataType)
-            {
-                case 0: //index
-                    cJSON_AddNumberToObject(animationResult, "index", options->sequenceData[i]->frameData[j]->resultData->index);
-                    break;
-                
-                case 1: //SRT
-                    cJSON_AddNumberToObject(animationResult, "index", options->sequenceData[i]->frameData[j]->resultData->dataSrt.index);
-                    cJSON_AddNumberToObject(animationResult, "rotation", options->sequenceData[i]->frameData[j]->resultData->dataSrt.rotation);
-                    cJSON_AddNumberToObject(animationResult, "scaleX", options->sequenceData[i]->frameData[j]->resultData->dataSrt.scaleX);
-                    cJSON_AddNumberToObject(animationResult, "scaleY", options->sequenceData[i]->frameData[j]->resultData->dataSrt.scaleY);
-                    cJSON_AddNumberToObject(animationResult, "positionX", options->sequenceData[i]->frameData[j]->resultData->dataSrt.positionX);
-                    cJSON_AddNumberToObject(animationResult, "positionY", options->sequenceData[i]->frameData[j]->resultData->dataSrt.positionY);
-                    break;
-
-                case 2: //T
-                    cJSON_AddNumberToObject(animationResult, "index", options->sequenceData[i]->frameData[j]->resultData->dataT.index);
-                    cJSON_AddNumberToObject(animationResult, "positionX", options->sequenceData[i]->frameData[j]->resultData->dataT.positionX);
-                    cJSON_AddNumberToObject(animationResult, "positionY", options->sequenceData[i]->frameData[j]->resultData->dataT.positionY);
-                    break;
-            }
-
+            cJSON_AddNumberToObject(frame, "resultId", options->sequenceData[i]->frameData[j]->resultId);
             cJSON_AddItemToArray(frameData, frame);
         }
 
         cJSON_AddItemToArray(sequences, sequence);
     }
 
+    cJSON *animationResults = cJSON_AddArrayToObject(nanr, "animationResults");
+    for (int i = 0; i < options->resultCount; i++)
+    {
+        cJSON *animationResult = cJSON_CreateObject();
+        switch(options->animationResults[i]->dataType)
+        {
+            case 0: //index
+                cJSON_AddNumberToObject(animationResult, "index", options->animationResults[i]->index);
+                break;
+            
+            case 1: //SRT
+                cJSON_AddNumberToObject(animationResult, "index", options->animationResults[i]->dataSrt.index);
+                cJSON_AddNumberToObject(animationResult, "rotation", options->animationResults[i]->dataSrt.rotation);
+                cJSON_AddNumberToObject(animationResult, "scaleX", options->animationResults[i]->dataSrt.scaleX);
+                cJSON_AddNumberToObject(animationResult, "scaleY", options->animationResults[i]->dataSrt.scaleY);
+                cJSON_AddNumberToObject(animationResult, "positionX", options->animationResults[i]->dataSrt.positionX);
+                cJSON_AddNumberToObject(animationResult, "positionY", options->animationResults[i]->dataSrt.positionY);
+                break;
+
+            case 2: //T
+                cJSON_AddNumberToObject(animationResult, "index", options->animationResults[i]->dataT.index);
+                cJSON_AddNumberToObject(animationResult, "positionX", options->animationResults[i]->dataT.positionX);
+                cJSON_AddNumberToObject(animationResult, "positionY", options->animationResults[i]->dataT.positionY);
+                break;
+        }
+
+        cJSON_AddItemToArray(animationResults, animationResult);
+    }
+    
     if (options->labelEnabled)
     {
         cJSON *labels = cJSON_CreateStringArray((const char * const*)options->labels, options->labelCount);
@@ -856,7 +883,7 @@ void FreeNANRAnimation_New(struct JsonToAnimationOptions_New *options)
     {
         for (int j = 0; j < options->sequenceData[i]->frameCount; j++)
         {
-            free(options->sequenceData[i]->frameData[j]->resultData);
+            free(options->animationResults[i]);
             free(options->sequenceData[i]->frameData[j]);
         }
         free(options->sequenceData[i]->frameData);

--- a/json.h
+++ b/json.h
@@ -9,9 +9,12 @@ struct JsonToCellOptions *ParseNCERJson(char *path);
 char *GetNCERJson(struct JsonToCellOptions *options);
 struct JsonToScreenOptions *ParseNSCRJson(char *path);
 struct JsonToAnimationOptions *ParseNANRJson(char *path);
+struct JsonToAnimationOptions_New *ParseNANRJson_New(char *path);
 char *GetNANRJson(struct JsonToAnimationOptions *options);
+char *GetNANRJson_New(struct JsonToAnimationOptions_New *options);
 void FreeNCERCell(struct JsonToCellOptions *options);
 void FreeNSCRScreen(struct JsonToScreenOptions *options);
 void FreeNANRAnimation(struct JsonToAnimationOptions *options);
+void FreeNANRAnimation_New(struct JsonToAnimationOptions_New *options);
 
 #endif //JSON_H

--- a/main.c
+++ b/main.c
@@ -846,30 +846,70 @@ void HandleJsonToNtrScreenCommand(char *inputPath, char *outputPath, int argc UN
     FreeNSCRScreen(options);
 }
 
-void HandleJsonToNtrAnimationCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
+void HandleJsonToNtrAnimationCommand(char *inputPath, char *outputPath, int argc, char **argv)
 {
-    struct JsonToAnimationOptions *options;
+    bool useNewNANRParser = false;
+    for (int i = 3; i < argc; i++)
+    {
+        char *option = argv[i];
 
-    options = ParseNANRJson(inputPath);
+        if (strcmp(option, "-newparser") == 0)
+        {
+            useNewNANRParser = true;
+        }
+        else
+        {
+            FATAL_ERROR("Unrecognized option \"%s\".\n", option);
+        }
+    }
 
-    options->multiCell = false;
-
-    WriteNtrAnimation(outputPath, options);
-
-    FreeNANRAnimation(options);
+    if (useNewNANRParser) 
+    {
+        struct JsonToAnimationOptions_New *options = ParseNANRJson_New(inputPath);
+        options->multiCell = false;
+        WriteNtrAnimation_New(outputPath, options);
+        FreeNANRAnimation_New(options);
+    } else 
+    {
+        struct JsonToAnimationOptions *options = ParseNANRJson(inputPath);
+        options->multiCell = false;
+        WriteNtrAnimation(outputPath, options);
+        FreeNANRAnimation(options);
+    }
 }
 
 void HandleNtrAnimationToJsonCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
 {
-    struct JsonToAnimationOptions *options = malloc(sizeof(struct JsonToAnimationOptions));
+    bool useNewNANRParser = false;
+    for (int i = 3; i < argc; i++)
+    {
+        char *option = argv[i];
 
-    ReadNtrAnimation(inputPath, options);
+        if (strcmp(option, "-newparser") == 0)
+        {
+            useNewNANRParser = true;
+        }
+        else
+        {
+            FATAL_ERROR("Unrecognized option \"%s\".\n", option);
+        }
+    }
 
-    char *json = GetNANRJson(options);
-
-    WriteWholeStringToFile(outputPath, json);
-
-    FreeNANRAnimation(options);
+    if (useNewNANRParser) 
+    {
+        struct JsonToAnimationOptions_New *options = malloc(sizeof(struct JsonToAnimationOptions_New));
+        ReadNtrAnimation_New(inputPath, options);
+        char *json = GetNANRJson_New(options);
+        WriteWholeStringToFile(outputPath, json);
+        FreeNANRAnimation_New(options);
+    } else 
+    {
+        struct JsonToAnimationOptions *options = malloc(sizeof(struct JsonToAnimationOptions));
+        ReadNtrAnimation(inputPath, options);
+        char *json = GetNANRJson(options);
+        WriteWholeStringToFile(outputPath, json);
+        FreeNANRAnimation(options);
+    }
 }
 
 void HandleJsonToNtrMulticellAnimationCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)

--- a/options.h
+++ b/options.h
@@ -131,6 +131,7 @@ struct SequenceData {
 
 struct FrameData_New {
     short frameDelay;
+    int dataOffset;
     int resultId;
 };
 
@@ -170,7 +171,7 @@ struct AnimationResults {
 };
 
 struct AnimationResults_New {
-    int resultId;
+    int dataOffset;
     int dataType;
     union {
         short index;

--- a/options.h
+++ b/options.h
@@ -131,8 +131,7 @@ struct SequenceData {
 
 struct FrameData_New {
     short frameDelay;
-    int dataOffset;
-    struct AnimationResults *resultData;
+    int resultId;
 };
 
 struct SequenceData_New {
@@ -170,6 +169,16 @@ struct AnimationResults {
     };
 };
 
+struct AnimationResults_New {
+    int resultId;
+    int dataType;
+    union {
+        short index;
+        struct AnimationDataSRT dataSrt;
+        struct AnimationDataT dataT;
+    };
+};
+
 struct JsonToAnimationOptions {
     bool multiCell;
     short sequenceCount;
@@ -187,9 +196,11 @@ struct JsonToAnimationOptions_New {
     short sequenceCount;
     short frameCount;
     struct SequenceData_New **sequenceData;
+    struct AnimationResults_New **animationResults;
     bool labelEnabled;
     char **labels;
     int labelCount;
+    int resultCount;
 };
 
 #endif // OPTIONS_H

--- a/options.h
+++ b/options.h
@@ -129,6 +129,22 @@ struct SequenceData {
     struct FrameData **frameData;
 };
 
+struct FrameData_New {
+    short frameDelay;
+    int dataOffset;
+    struct AnimationResults *resultData;
+};
+
+struct SequenceData_New {
+    short frameCount;
+    short unk02;
+    short dataType;
+    short unk06;
+    int unk08;
+    int headerOffset;
+    struct FrameData_New **frameData;
+};
+
 struct AnimationDataSRT {
     short index;
     unsigned short rotation;
@@ -164,6 +180,16 @@ struct JsonToAnimationOptions {
     char **labels;
     int labelCount;
     short resultCount;
+};
+
+struct JsonToAnimationOptions_New {
+    bool multiCell;
+    short sequenceCount;
+    short frameCount;
+    struct SequenceData_New **sequenceData;
+    bool labelEnabled;
+    char **labels;
+    int labelCount;
 };
 
 #endif // OPTIONS_H

--- a/options.h
+++ b/options.h
@@ -173,6 +173,7 @@ struct AnimationResults {
 struct AnimationResults_New {
     int dataOffset;
     int dataType;
+    bool padded;
     union {
         short index;
         struct AnimationDataSRT dataSrt;


### PR DESCRIPTION
The existing routines for NANRs can't correctly rebuild the NANR files from `pl_batt_obj.narc` in pokeplatinum. This PR includes a reimplementation of NANR read/write partially based on documentation under http://llref.emutalk.net/docs/?file=xml/nanr.xml#xml-doc.

The reimplementation has breaking changes to the JSON file used for input to rebuild NANR so I hid it behind an option as an alternative parsing method.

It's able to rebuild all 55 NANRs for pl_batt_obj so I feel OK about it, but obviously am not 100% sure about correctness against other NANRs. Might need to be tested for other complicated cases.