### PR TITLE
update NANR parser to handle resultType better and handle padding

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -1327,8 +1327,8 @@ void ReadNtrAnimation(char *path, struct JsonToAnimationOptions *options)
     {
         options->sequenceData[i]->frameCount = data[offset] | (data[offset + 1] << 8);
         options->sequenceData[i]->loopStartFrame = data[offset + 2] | (data[offset + 3] << 8);
-        options->sequenceData[i]->animationType = data[offset + 4] | (data[offset + 5] << 8);
-        options->sequenceData[i]->animationType2 = data[offset + 6] | (data[offset + 7] << 8);
+        options->sequenceData[i]->animationElement = data[offset + 4] | (data[offset + 5] << 8);
+        options->sequenceData[i]->animationType = data[offset + 6] | (data[offset + 7] << 8);
         options->sequenceData[i]->playbackMode = data[offset + 8] | (data[offset + 9] << 8) | (data[offset + 10] << 16) | (data[offset + 11] << 24);
         frameOffsets[i] = data[offset + 12] | (data[offset + 13] << 8) | (data[offset + 14] << 16) | (data[offset + 15] << 24);
 
@@ -1402,12 +1402,12 @@ void ReadNtrAnimation(char *path, struct JsonToAnimationOptions *options)
         options->animationResults[i] = malloc(sizeof(struct AnimationResults));
     }
 
-    // store the animationType of the corresponding sequence as this result's resultType
+    // store the animationElement of the corresponding sequence as this result's resultType
     for (int i = 0; i < options->sequenceCount; i++)
     {
         for (int j = 0; j < options->sequenceData[i]->frameCount; j++)
         {
-            options->animationResults[options->sequenceData[i]->frameData[j]->resultId]->resultType = options->sequenceData[i]->animationType;
+            options->animationResults[options->sequenceData[i]->frameData[j]->resultId]->resultType = options->sequenceData[i]->animationElement;
         }
     }
 
@@ -1612,10 +1612,10 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
         KBNAContents[i + 1] = options->sequenceData[i / 0x10]->frameCount >> 8;
         KBNAContents[i + 2] = options->sequenceData[i / 0x10]->loopStartFrame & 0xff;
         KBNAContents[i + 3] = options->sequenceData[i / 0x10]->loopStartFrame >> 8;
-        KBNAContents[i + 4] = options->sequenceData[i / 0x10]->animationType & 0xff;
-        KBNAContents[i + 5] = (options->sequenceData[i / 0x10]->animationType >> 8) & 0xff;
-        KBNAContents[i + 6] = options->sequenceData[i / 0x10]->animationType2 & 0xff;
-        KBNAContents[i + 7] = (options->sequenceData[i / 0x10]->animationType2 >> 8) & 0xff;
+        KBNAContents[i + 4] = options->sequenceData[i / 0x10]->animationElement & 0xff;
+        KBNAContents[i + 5] = (options->sequenceData[i / 0x10]->animationElement >> 8) & 0xff;
+        KBNAContents[i + 6] = options->sequenceData[i / 0x10]->animationType & 0xff;
+        KBNAContents[i + 7] = (options->sequenceData[i / 0x10]->animationType >> 8) & 0xff;
         KBNAContents[i + 8] = options->sequenceData[i / 0x10]->playbackMode & 0xff;
         KBNAContents[i + 9] = (options->sequenceData[i / 0x10]->playbackMode >> 8) & 0xff;
         KBNAContents[i + 10] = (options->sequenceData[i / 0x10]->playbackMode >> 16) & 0xff;

--- a/gfx.c
+++ b/gfx.c
@@ -1516,6 +1516,7 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
     {
         int sequenceLen = 0;
         int resultIndex = 0;
+        int lastNewResultIndex = -1;
         for (int j = 0; j < options->sequenceData[i]->frameCount; j++)
         {
             // check if the result has already been used
@@ -1532,6 +1533,7 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
                 if (usedResults[resultIndex] == -1)
                 {
                     usedResults[resultIndex] = options->sequenceData[i]->frameData[j]->resultId;
+                    lastNewResultIndex = options->sequenceData[i]->frameData[j]->resultId;
                     break;
                 }
             }
@@ -1547,11 +1549,11 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
                     sequenceLen += 0x8;
             }
         }
-        if (sequenceLen % 4 != 0) 
+        if (sequenceLen % 4 != 0 && lastNewResultIndex != -1)
         {
             totalSize += 0x02;
-            // mark the last animationResult for the sequence as padded, this saves needing to check this again later
-            options->animationResults[resultIndex]->padded = true;
+            // mark the last new animationResult index for the sequence as padded, this saves needing to check this again later
+            options->animationResults[lastNewResultIndex]->padded = true;
         }
     }
 

--- a/gfx.c
+++ b/gfx.c
@@ -1519,10 +1519,12 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
         for (int j = 0; j < options->sequenceData[i]->frameCount; j++)
         {
             // check if the result has already been used
+            bool isUsed = false;
             for (resultIndex = 0; resultIndex < options->resultCount; resultIndex++)
             {
                 if (usedResults[resultIndex] == options->sequenceData[i]->frameData[j]->resultId)
                 {
+                    isUsed = true;
                     break;
                 }
 
@@ -1535,12 +1537,15 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
             }
 
             // if not already used, add it to the result size for the sequence
-            if (options->animationResults[resultIndex]->resultType == 0)
-                sequenceLen += 0x2;
-            else if (options->animationResults[resultIndex]->resultType == 1)
-                sequenceLen += 0x10;
-            else if (options->animationResults[resultIndex]->resultType == 2)
-                sequenceLen += 0x8;
+            if (!isUsed)
+            {
+                if (options->animationResults[resultIndex]->resultType == 0)
+                    sequenceLen += 0x2;
+                else if (options->animationResults[resultIndex]->resultType == 1)
+                    sequenceLen += 0x10;
+                else if (options->animationResults[resultIndex]->resultType == 2)
+                    sequenceLen += 0x8;
+            }
         }
         if (sequenceLen % 4 != 0) 
         {

--- a/gfx.c
+++ b/gfx.c
@@ -1555,6 +1555,8 @@ void WriteNtrAnimation(char *path, struct JsonToAnimationOptions *options)
         }
     }
 
+    free(usedResults);
+
     unsigned int KNBASize = totalSize;
 
     if (options->labelEnabled)

--- a/json.c
+++ b/json.c
@@ -376,14 +376,14 @@ struct JsonToAnimationOptions *ParseNANRJson(char *path)
 
         cJSON *frameCount = cJSON_GetObjectItemCaseSensitive(sequence, "frameCount");
         cJSON *loopStartFrame = cJSON_GetObjectItemCaseSensitive(sequence, "loopStartFrame");
+        cJSON *animationElement = cJSON_GetObjectItemCaseSensitive(sequence, "animationElement");
         cJSON *animationType = cJSON_GetObjectItemCaseSensitive(sequence, "animationType");
-        cJSON *animationType2 = cJSON_GetObjectItemCaseSensitive(sequence, "animationType2");
         cJSON *playbackMode = cJSON_GetObjectItemCaseSensitive(sequence, "playbackMode");
 
         options->sequenceData[i]->frameCount = GetInt(frameCount);
         options->sequenceData[i]->loopStartFrame = GetInt(loopStartFrame);
+        options->sequenceData[i]->animationElement = GetInt(animationElement);
         options->sequenceData[i]->animationType = GetInt(animationType);
-        options->sequenceData[i]->animationType2 = GetInt(animationType2);
         options->sequenceData[i]->playbackMode = GetInt(playbackMode);
 
         options->sequenceData[i]->frameData = malloc(sizeof(struct FrameData *) * options->sequenceData[i]->frameCount);
@@ -521,8 +521,8 @@ char *GetNANRJson(struct JsonToAnimationOptions *options)
         cJSON *sequence = cJSON_CreateObject();
         cJSON_AddNumberToObject(sequence, "frameCount", options->sequenceData[i]->frameCount);
         cJSON_AddNumberToObject(sequence, "loopStartFrame", options->sequenceData[i]->loopStartFrame);
+        cJSON_AddNumberToObject(sequence, "animationElement", options->sequenceData[i]->animationElement);
         cJSON_AddNumberToObject(sequence, "animationType", options->sequenceData[i]->animationType);
-        cJSON_AddNumberToObject(sequence, "animationType2", options->sequenceData[i]->animationType2);
         cJSON_AddNumberToObject(sequence, "playbackMode", options->sequenceData[i]->playbackMode);
 
         cJSON *frameData = cJSON_AddArrayToObject(sequence, "frameData");

--- a/json.c
+++ b/json.c
@@ -376,14 +376,14 @@ struct JsonToAnimationOptions *ParseNANRJson(char *path)
 
         cJSON *frameCount = cJSON_GetObjectItemCaseSensitive(sequence, "frameCount");
         cJSON *loopStartFrame = cJSON_GetObjectItemCaseSensitive(sequence, "loopStartFrame");
-        cJSON *animationElement = cJSON_GetObjectItemCaseSensitive(sequence, "animationElement");
         cJSON *animationType = cJSON_GetObjectItemCaseSensitive(sequence, "animationType");
+        cJSON *animationType2 = cJSON_GetObjectItemCaseSensitive(sequence, "animationType2");
         cJSON *playbackMode = cJSON_GetObjectItemCaseSensitive(sequence, "playbackMode");
 
         options->sequenceData[i]->frameCount = GetInt(frameCount);
         options->sequenceData[i]->loopStartFrame = GetInt(loopStartFrame);
-        options->sequenceData[i]->animationElement = GetInt(animationElement);
         options->sequenceData[i]->animationType = GetInt(animationType);
+        options->sequenceData[i]->animationType2 = GetInt(animationType2);
         options->sequenceData[i]->playbackMode = GetInt(playbackMode);
 
         options->sequenceData[i]->frameData = malloc(sizeof(struct FrameData *) * options->sequenceData[i]->frameCount);
@@ -521,8 +521,8 @@ char *GetNANRJson(struct JsonToAnimationOptions *options)
         cJSON *sequence = cJSON_CreateObject();
         cJSON_AddNumberToObject(sequence, "frameCount", options->sequenceData[i]->frameCount);
         cJSON_AddNumberToObject(sequence, "loopStartFrame", options->sequenceData[i]->loopStartFrame);
-        cJSON_AddNumberToObject(sequence, "animationElement", options->sequenceData[i]->animationElement);
         cJSON_AddNumberToObject(sequence, "animationType", options->sequenceData[i]->animationType);
+        cJSON_AddNumberToObject(sequence, "animationType2", options->sequenceData[i]->animationType2);
         cJSON_AddNumberToObject(sequence, "playbackMode", options->sequenceData[i]->playbackMode);
 
         cJSON *frameData = cJSON_AddArrayToObject(sequence, "frameData");

--- a/options.h
+++ b/options.h
@@ -123,8 +123,8 @@ struct FrameData {
 struct SequenceData {
     short frameCount;
     short loopStartFrame;
-    short animationElement;
     short animationType;
+    short animationType2;
     int playbackMode;
     struct FrameData **frameData;
 };
@@ -147,6 +147,7 @@ struct AnimationDataT {
 
 struct AnimationResults {
     short resultType;
+    bool padded;
     union {
         short index;
         struct AnimationDataSRT dataSrt;

--- a/options.h
+++ b/options.h
@@ -123,8 +123,8 @@ struct FrameData {
 struct SequenceData {
     short frameCount;
     short loopStartFrame;
+    short animationElement;
     short animationType;
-    short animationType2;
     int playbackMode;
     struct FrameData **frameData;
 };


### PR DESCRIPTION
moved the changes from #13 into the existing NANR processing routines. main changes are listed below:

- determine the resultType field for each animationResult from the type of the sequence instead of inferring from the data layout
- properly apply 0xCCCC padding where required (only when the results for a sequence are not 4-byte aligned)

the below is irrelevant, I misread the spec + corrected it since

~~also 1 likely breaking change which will need to be reviewed on how to handle:~~

~~- remove `animationElement` field in SequenceData, read `animationType` from the location this was coming from~~

~~(the G2d spec actually states `animationType` is a u32 at this location, but from testing against real NANR files, it's apparent `animationType` is only the first 2 bytes of this field + the second half of the field is used for something else undocumented)~~

~~i opted to rename the JSON fields for this (`animationElement` -> `animationType`, `animationType` -> `animationType2`) which would be breaking for existing files. it would be easy (but maybe confusing to maintain) to just keep the existing names and use `animationElement` for the type for each result.~~