### PR TITLE
support NCLR files with unusual inverted size field

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -714,7 +714,7 @@ void ReadGbaPalette(char *path, struct Palette *palette)
     free(data);
 }
 
-void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex)
+void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool inverted)
 {
     int fileSize;
     unsigned char *data = ReadWholeFile(path, &fileSize);
@@ -739,6 +739,7 @@ void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIn
     bitdepth = bitdepth ? bitdepth : palette->bitDepth;
 
     size_t paletteSize = (paletteHeader[0x10]) | (paletteHeader[0x11] << 8) | (paletteHeader[0x12] << 16) | (paletteHeader[0x13] << 24);
+    if (inverted) paletteSize = 0x200 - paletteSize;
     if (palIndex == 0) {
         palette->numColors = paletteSize / 2;
     } else {
@@ -789,7 +790,7 @@ void WriteGbaPalette(char *path, struct Palette *palette)
     fclose(fp);
 }
 
-void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp)
+void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, bool inverted)
 {
     FILE *fp = fopen(path, "wb");
 
@@ -843,10 +844,11 @@ void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, in
     }
 
     //size
-    palHeader[16] = size & 0xFF;
-    palHeader[17] = (size >> 8) & 0xFF;
-    palHeader[18] = (size >> 16) & 0xFF;
-    palHeader[19] = (size >> 24) & 0xFF;
+    int colorSize = inverted ? 0x200 - size : size;
+    palHeader[16] = colorSize & 0xFF;
+    palHeader[17] = (colorSize >> 8) & 0xFF;
+    palHeader[18] = (colorSize >> 16) & 0xFF;
+    palHeader[19] = (colorSize >> 24) & 0xFF;
 
     fwrite(palHeader, 1, 0x18, fp);
 

--- a/gfx.h
+++ b/gfx.h
@@ -58,9 +58,9 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int
                    uint32_t mappingType, uint32_t key, bool wrongSize);
 void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
-void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex);
+void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool inverted);
 void WriteGbaPalette(char *path, struct Palette *palette);
-void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp);
+void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, bool inverted);
 void ReadNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrScreen(char *path, struct JsonToScreenOptions *options);

--- a/main.c
+++ b/main.c
@@ -74,7 +74,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     if (options->paletteFilePath != NULL)
     {
-        ReadNtrPalette(options->paletteFilePath, &image.palette, options->bitDepth, options->palIndex);
+        ReadNtrPalette(options->paletteFilePath, &image.palette, options->bitDepth, options->palIndex, false);
         image.hasPalette = true;
     }
     else
@@ -619,7 +619,7 @@ void HandlePngToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, c
     }
 
     ReadPngPalette(inputPath, &palette);
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, false);
 }
 
 void HandleGbaToJascPaletteCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
@@ -634,6 +634,7 @@ void HandleNtrToJascPaletteCommand(char *inputPath, char *outputPath, int argc, 
 {
     struct Palette palette;
     int bitdepth = 0;
+    bool inverted = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -652,13 +653,17 @@ void HandleNtrToJascPaletteCommand(char *inputPath, char *outputPath, int argc, 
             if (bitdepth != 4 && bitdepth != 8)
                 FATAL_ERROR("Bitdepth must be 4 or 8.\n");
         }
+        else if (strcmp(option, "-invertsize") == 0)
+        {
+            inverted = true;
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
         }
     }
 
-    ReadNtrPalette(inputPath, &palette, bitdepth, 0);
+    ReadNtrPalette(inputPath, &palette, bitdepth, 0, inverted);
     WriteJascPalette(outputPath, &palette);
 }
 
@@ -708,6 +713,7 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     int bitdepth = 0;
     int compNum = 0;
     bool pcmp = false;
+    bool inverted = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -768,6 +774,10 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
         {
             pcmp = true;
         }
+        else if (strcmp(option, "-invertsize") == 0)
+        {
+            inverted = true;
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
@@ -781,7 +791,7 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     if (numColors != 0)
         palette.numColors = numColors;
 
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted);
 }
 
 void HandleJsonToNtrCellCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)


### PR DESCRIPTION
for a set of NCLR files in platinum which treat the `size` field weirdly. there's an example from `config_gra.narc` and around 80 examples from `pl_batt_obj.narc` which use `0x200 - size` in this field instead of the real size.

I had also noticed all the examples I looked at in pokeplatinum with this `size` discrepancy also have a `PCMP` block but it looks like pokeheartgold has a counter-example so it's likely just coincidence (or something specific to platinum)