### PR TITLE
Update KBEC size to account for 4-byte aligment

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -1112,6 +1112,9 @@ void WriteNtrCell(char *path, struct JsonToCellOptions *options)
         kbecSize += options->cells[idx / iterNum]->oamCount * 0x06;
     }
 
+    // KBEC size is padded to be 4-byte aligned
+    kbecSize += kbecSize % 4;
+
     unsigned int totalSize = (options->labelEnabled > 0 ? 0x34 : 0x20) + kbecSize;
 
     if (options->labelEnabled)


### PR DESCRIPTION
In the json->NCER conversion, the KBEC size field was not properly being set when the contents were not 4-byte aligned. This was tested for matching on all currently decomped NCERs in both pokeplatinum and pokeheartgold. Leaving in draft for now to get further confirmation.