### PR TITLE
add flag to build NCER files which do not pad

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -1113,7 +1113,7 @@ void WriteNtrCell(char *path, struct JsonToCellOptions *options)
     }
 
     // KBEC size is padded to be 4-byte aligned
-    kbecSize += kbecSize % 4;
+    if (options->padOAM) kbecSize += kbecSize % 4;
 
     unsigned int totalSize = (options->labelEnabled > 0 ? 0x34 : 0x20) + kbecSize;
 

--- a/main.c
+++ b/main.c
@@ -801,11 +801,22 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted);
 }
 
-void HandleJsonToNtrCellCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
+void HandleJsonToNtrCellCommand(char *inputPath, char *outputPath, int argc, char **argv)
 {
     struct JsonToCellOptions *options;
 
     options = ParseNCERJson(inputPath);
+    options->padOAM = true;
+
+    for (int i = 3; i < argc; i++)
+    {
+        char *option = argv[i];
+
+        if (strcmp(option, "-nopadoam") == 0)
+        {
+            options->padOAM = false;
+        }
+    }
 
     WriteNtrCell(outputPath, options);
 

--- a/options.h
+++ b/options.h
@@ -113,6 +113,7 @@ struct JsonToCellOptions {
     struct CellVramTransferData **transferData;
     char **labels;
     int labelCount;
+    bool padOAM;
 };
 
 struct JsonToScreenOptions {


### PR DESCRIPTION
according to g2d spec for NCER OAM data:

`In the file data, attribute data is stored in the form {attr0,attr1,attr2}, {attr0,attr1,attr2}, and so
on. Because the end of the OAM attribute information string must be 4-byte aligned, the correct
padding information must be inserted in the data.`

`pl_batt_obj.narc` has a handful of NCER files which don't respect this part of the spec and don't include any padding. this PR adds the padding by default (which is correct according to spec) and adds a flag to disable this padding if needed.