### PR TITLE
Add a flag to disable padding lz-encoded files

### DIFF
--- a/lz.c
+++ b/lz.c
@@ -122,7 +122,7 @@ static void FindBestBlockBackwards(unsigned char *src, int srcPos, int srcSize, 
 
 typedef void (*FindBestBlockFunc)(unsigned char *src, int srcPos, int srcSize, const int minDistance, int *outBestBlockDistance, int *outBestBlockSize);
 
-unsigned char *LZCompress(unsigned char *src, int srcSize, int *compressedSize, const int minDistance, bool forwardIteration)
+unsigned char *LZCompress(unsigned char *src, int srcSize, int *compressedSize, const int minDistance, bool forwardIteration, bool pad)
 {
     if (srcSize <= 0)
         goto fail;
@@ -169,12 +169,14 @@ unsigned char *LZCompress(unsigned char *src, int srcSize, int *compressedSize, 
             }
 
             if (srcPos == srcSize) {
-                // Pad to multiple of 4 bytes.
-                int remainder = destPos % 4;
+                if (pad) {
+                    // Pad to multiple of 4 bytes.
+                    int remainder = destPos % 4;
 
-                if (remainder != 0) {
-                    for (int i = 0; i < 4 - remainder; i++)
-                        dest[destPos++] = 0;
+                    if (remainder != 0) {
+                        for (int i = 0; i < 4 - remainder; i++)
+                            dest[destPos++] = 0;
+                    }
                 }
 
                 *compressedSize = destPos;

--- a/lz.h
+++ b/lz.h
@@ -6,6 +6,6 @@
 #include "stdbool.h"
 
 unsigned char *LZDecompress(unsigned char *src, int srcSize, int *uncompressedSize);
-unsigned char *LZCompress(unsigned char *src, int srcSize, int *compressedSize, const int minDistance, bool forwardIteration);
+unsigned char *LZCompress(unsigned char *src, int srcSize, int *compressedSize, const int minDistance, bool forwardIteration, bool pad);
 
 #endif // LZ_H

--- a/main.c
+++ b/main.c
@@ -973,6 +973,7 @@ void HandleLZCompressCommand(char *inputPath, char *outputPath, int argc, char *
     int overflowSize = 0;
     int minDistance = 2; // default, for compatibility with LZ77UnCompVram()
     bool forwardIteration = true;
+    bool nopad = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -1008,6 +1009,10 @@ void HandleLZCompressCommand(char *inputPath, char *outputPath, int argc, char *
         {
             forwardIteration = false;
         }
+        else if (strcmp(option, "-nopad") == 0)
+        {
+            nopad = true;
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
@@ -1024,7 +1029,7 @@ void HandleLZCompressCommand(char *inputPath, char *outputPath, int argc, char *
     unsigned char *buffer = ReadWholeFileZeroPadded(inputPath, &fileSize, overflowSize);
 
     int compressedSize;
-    unsigned char *compressedData = LZCompress(buffer, fileSize + overflowSize, &compressedSize, minDistance, forwardIteration);
+    unsigned char *compressedData = LZCompress(buffer, fileSize + overflowSize, &compressedSize, minDistance, forwardIteration, !nopad);
 
     compressedData[1] = (unsigned char)fileSize;
     compressedData[2] = (unsigned char)(fileSize >> 8);


### PR DESCRIPTION
I stumbled upon some lz-encoded files that were not padded to a multiple of 4 bytes in Pokemon Platinum, specifically in `mystery.narc`, although these are probably not the only examples. This adds a flag to allow disabling padding when lz-encoding files.