### PR TITLE
Add a flag to place NCGR tiles with a NCER file

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include "global.h"
 #include "gfx.h"
+#include "json.h"
 #include "util.h"
 
 static unsigned int FindNitroDataBlock(const unsigned char *data, const char *ident, unsigned int fileSize, unsigned int *blockSize_out)
@@ -796,6 +797,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         }
     }
 
+    free(image->pixels);
     if (toPNG)
     {
         image->pixels = newPixels;
@@ -809,7 +811,6 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         image->width = 8;
     }
     FreeNCERCell(options);
-    free(newPixels);
 }
 
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors)

--- a/gfx.c
+++ b/gfx.c
@@ -623,6 +623,10 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         }
     }
 
+    if (outputHeight == 0 || outputWidth == 0)
+    {
+        FATAL_ERROR("No cells. Incompatible NCER\n");
+    }
     unsigned char *newPixels = malloc(outputHeight * outputWidth);
     memset(newPixels, 255, outputHeight * outputWidth);
 
@@ -804,6 +808,8 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         image->height = numTiles * 8;
         image->width = 8;
     }
+    FreeNCERCell(options);
+    free(newPixels);
 }
 
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors)

--- a/gfx.c
+++ b/gfx.c
@@ -588,7 +588,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
     unsigned char *newPixels = malloc(imageSize);
     memset(newPixels, 0, imageSize);
 
-    for (int i = 0; i < options->cellCount && outputHeight * outputWidth < image->height * image->width; i++)
+    for (int i = 0; i < options->cellCount && outputHeight * outputWidth < imageSize; i++)
     {
         int cellHeight = 0;
         int cellWidth = 0;

--- a/gfx.c
+++ b/gfx.c
@@ -595,10 +595,16 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         }
         else
         {
-            newheight = options->cells[i]->maxY - options->cells[i]->minY + 1;
-            newwidth = options->cells[i]->maxX - options->cells[i]->minX + 1;
+            if (options->cells[i]->attributes.boundingRect)
+            {
+                newheight = options->cells[i]->maxY - options->cells[i]->minY + 1;
+                newwidth = options->cells[i]->maxX - options->cells[i]->minX + 1;
+            }
+            else
+            {
+                FATAL_ERROR("No bounding rectangle. Incompatible NCER\n");
+            }
         }
-        int tilesUsed = 0;
 
         for (int j = 0; j < options->cells[i]->oamCount; j++)
         {
@@ -712,9 +718,18 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
         }
     }
 
-    image->pixels = newPixels;
-    image->height = outputHeight;
-    image->width = outputWidth;
+    if (toPNG)
+    {
+        image->pixels = newPixels;
+        image->height = outputHeight;
+        image->width = outputWidth;
+    }
+    else
+    {
+        image->pixels = newPixels;
+        image->height = imageSize / 8;
+        image->width = 8;
+    }
 }
 
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors)

--- a/gfx.c
+++ b/gfx.c
@@ -635,7 +635,6 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
 
         newheight = endY - startY + lastYPixels;
         newwidth = endX - startX + lastXPixels;
-        printf("x = %d, y = %d\n", newwidth, newheight);
 
         for (int j = 0; j < options->cells[i]->oamCount; j++)
         {

--- a/gfx.h
+++ b/gfx.h
@@ -52,6 +52,7 @@ struct Image {
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
+void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,

--- a/main.c
+++ b/main.c
@@ -98,6 +98,11 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     image.hasTransparency = options->hasTransparency;
 
+    if (options->cellFilePath != NULL)
+    {
+        ApplyCellsToImage(options->cellFilePath, &image, true);
+    }
+
     WritePng(outputPath, &image);
 
     FreeImage(&image);
@@ -161,6 +166,11 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
     }
 
     options->bitDepth = options->bitDepth == 0 ? image.bitDepth : options->bitDepth;
+
+    if (options->cellFilePath != NULL)
+    {
+        ApplyCellsToImage(options->cellFilePath, &image, false);
+    }
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,
                   &image, !image.hasPalette, options->clobberSize, options->byteOrder, options->version101,
@@ -255,6 +265,7 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
 {
     struct NtrToPngOptions options;
     options.paletteFilePath = NULL;
+    options.cellFilePath = NULL;
     options.hasTransparency = false;
     options.width = 0;
     options.colsPerChunk = 1;
@@ -275,6 +286,15 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
             i++;
 
             options.paletteFilePath = argv[i];
+        }
+        else if (strcmp(option, "-cell") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No cell file path following \"-cell\".\n");
+
+            i++;
+
+            options.cellFilePath = argv[i];
         }
         else if (strcmp(option, "-object") == 0)
         {
@@ -421,6 +441,7 @@ void HandlePngToGbaCommand(char *inputPath, char *outputPath, int argc, char **a
 void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **argv)
 {
     struct PngToNtrOptions options;
+    options.cellFilePath = NULL;
     options.numTiles = 0;
     options.bitDepth = 0;
     options.colsPerChunk = 1;
@@ -451,6 +472,15 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
 
             if (options.numTiles < 1)
                 FATAL_ERROR("Number of tiles must be positive.\n");
+        }
+        else if (strcmp(option, "-cell") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No cell file path following \"-cell\".\n");
+
+            i++;
+
+            options.cellFilePath = argv[i];
         }
         else if (strcmp(option, "-mwidth") == 0 || strcmp(option, "-cpc") == 0)
         {

--- a/options.h
+++ b/options.h
@@ -24,6 +24,7 @@ struct PngToGbaOptions {
 };
 
 struct PngToNtrOptions {
+    char *cellFilePath;
     int numTiles;
     int bitDepth;
     int colsPerChunk;
@@ -41,6 +42,7 @@ struct PngToNtrOptions {
 
 struct NtrToPngOptions {
     char *paletteFilePath;
+    char *cellFilePath;
     int bitDepth;
     bool hasTransparency;
     int width;


### PR DESCRIPTION
This change attempts to make the `PNG`s output from `NCGR` files more easily editable.

Concept:
An `NCER` tells the game where to render each tile. This flag applies the cells to the image when converting `NCGR` -> `PNG`. The same `NCER` should then be used when converting `PNG` -> `NCGR` in order to return to the original file.

Use case:
This flag has purely aesthetic applications. The use of `NCER` is inherently lossy, so only cells without overlap between `OAM`s can be used. For cells that do not meet this criteria, a second dedicated `NCER` can be used for laying out the tiles. The program does check for duplicated tiles, but this is not perfect.

Additional notes:
When writing this I noticed that `struct Cell`'s coordinate values are not converted properly for negative values.