### PR TITLE
add options for dealing with 4bpp images with 256 colours

### DIFF
--- a/gfx.h
+++ b/gfx.h
@@ -51,17 +51,17 @@ struct Image {
 };
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex);
 void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
-                   uint32_t mappingType, uint32_t key, bool wrongSize);
+                   uint32_t mappingType, uint32_t key, bool wrongSize, bool convertTo4Bpp);
 void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
-void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool inverted);
+void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool inverted, bool convertTo8Bpp);
 void WriteGbaPalette(char *path, struct Palette *palette);
-void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, bool inverted);
+void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, bool inverted, bool convertTo4Bpp);
 void ReadNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrScreen(char *path, struct JsonToScreenOptions *options);

--- a/main.c
+++ b/main.c
@@ -79,7 +79,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
 
     if (options->paletteFilePath != NULL)
     {
-        ReadNtrPalette(options->paletteFilePath, &image.palette, options->bitDepth, options->palIndex, false);
+        ReadNtrPalette(options->paletteFilePath, &image.palette, options->bitDepth, options->palIndex, false, options->convertTo8Bpp);
         image.hasPalette = true;
     }
     else
@@ -87,7 +87,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
         image.hasPalette = false;
     }
 
-    uint32_t key = ReadNtrImage(inputPath, options->width, 0, options->colsPerChunk, options->rowsPerChunk, &image, !image.hasPalette, options->scanFrontToBack);
+    uint32_t key = ReadNtrImage(inputPath, options->width, 0, options->colsPerChunk, options->rowsPerChunk, &image, !image.hasPalette, options->scanFrontToBack, options->convertTo8Bpp, options->palIndex);
 
     if (key)
     {
@@ -181,7 +181,8 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
 
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,
                   &image, !image.hasPalette, options->clobberSize, options->byteOrder, options->version101,
-                  options->sopc, options->vramTransfer, options->scanMode, options->mappingType, key, options->wrongSize);
+                  options->sopc, options->vramTransfer, options->scanMode, options->mappingType, key, options->wrongSize,
+                  options->convertTo4Bpp);
 
     FreeImage(&image);
 }
@@ -280,6 +281,7 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
     options.palIndex = 1;
     options.scanFrontToBack = false;
     options.handleEmpty = false;
+    options.convertTo8Bpp = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -366,6 +368,10 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
         else if (strcmp(option, "-handleempty") == 0)
         {
             options.handleEmpty = true;
+        }
+        else if (strcmp(option, "-convertTo8Bpp") == 0)
+        {
+            options.convertTo8Bpp = true;
         }
         else
         {
@@ -469,6 +475,7 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
     options.handleEmpty = false;
     options.vramTransfer = false;
     options.mappingType = 0;
+    options.convertTo4Bpp = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -585,6 +592,10 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
             if (options.mappingType != 0 && options.mappingType != 32 && options.mappingType != 64 && options.mappingType != 128 && options.mappingType != 256)
                 FATAL_ERROR("bitdepth must be one of the following: 0, 32, 64, 128, or 256\n");
         }
+        else if (strcmp(option, "-convertTo4Bpp") == 0)
+        {
+            options.convertTo4Bpp = true;
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
@@ -621,6 +632,7 @@ void HandlePngToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, c
     int compNum = 0;
     bool pcmp = false;
     bool inverted = false;
+    bool convertTo4Bpp = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -672,6 +684,10 @@ void HandlePngToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, c
         {
             inverted = true;
         }
+        else if (strcmp(option, "-convertTo4Bpp") == 0)
+        {
+            convertTo4Bpp = true;
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
@@ -679,7 +695,7 @@ void HandlePngToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, c
     }
 
     ReadPngPalette(inputPath, &palette);
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted, convertTo4Bpp);
 }
 
 void HandleGbaToJascPaletteCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
@@ -723,7 +739,7 @@ void HandleNtrToJascPaletteCommand(char *inputPath, char *outputPath, int argc, 
         }
     }
 
-    ReadNtrPalette(inputPath, &palette, bitdepth, 0, inverted);
+    ReadNtrPalette(inputPath, &palette, bitdepth, 0, inverted, false);
     WriteJascPalette(outputPath, &palette);
 }
 
@@ -851,7 +867,7 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     if (numColors != 0)
         palette.numColors = numColors;
 
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, inverted, false);
 }
 
 void HandleJsonToNtrCellCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)

--- a/options.h
+++ b/options.h
@@ -38,6 +38,7 @@ struct PngToNtrOptions {
     bool handleEmpty;
     bool vramTransfer;
     int mappingType;
+    bool convertTo4Bpp;
 };
 
 struct NtrToPngOptions {
@@ -51,6 +52,7 @@ struct NtrToPngOptions {
     int palIndex;
     bool scanFrontToBack;
     bool handleEmpty;
+    bool convertTo8Bpp;
 };
 
 struct CellVramTransferData {


### PR DESCRIPTION
some images are 4bpp but have more than 16 colours because they can read from different rows of the palette. this adds options to export them as 8bpp pngs (with an additional option to specify which row of the palette is used in the resulting image), and to import 8bpp pngs as these types of images