### PR TITLE
Change pow to Bit Shift and Add json as Cell Input

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -664,7 +664,6 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
             scanHeight++;
         }
         int cellHeight = options->cells[i]->maxY - options->cells[i]->minY + 1;
-        int cellWidth = options->cells[i]->maxX - options->cells[i]->minX + 1;
         int uniqueOAMs = options->cells[i]->oamCount;
 
         for (int j = 0; j < options->cells[i]->oamCount; j++)
@@ -675,14 +674,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
             switch (options->cells[i]->oam[j].attr0.Shape)
             {
             case 0:
-                if (oamSize == 0)
-                {
-                    oamHeight = 1;
-                }
-                else
-                {
-                    oamHeight = 2 << oamSize - 1;
-                }
+                oamHeight = 1 << oamSize;
                 oamWidth = oamHeight;
                 break;
             case 1:

--- a/main.c
+++ b/main.c
@@ -1399,8 +1399,8 @@ int main(int argc, char **argv)
 
     for (int i = 0; handlers[i].function != NULL; i++)
     {
-        if ((handlers[i].inputFileExtension == NULL || strcmp(handlers[i].inputFileExtension, inputFileExtension) == 0)
-            && (handlers[i].outputFileExtension == NULL || strcmp(handlers[i].outputFileExtension, outputFileExtension) == 0)
+        if (((handlers[i].inputFileExtension == NULL || strcmp(handlers[i].inputFileExtension, inputFileExtension) == 0)
+            && (handlers[i].outputFileExtension == NULL || strcmp(handlers[i].outputFileExtension, outputFileExtension) == 0))
             || (handlers[i].inputFileExtension == NULL && strrchr(outputFileExtension, '.') && strstr(outputFileExtension, handlers[i].outputFileExtension))
             || (handlers[i].outputFileExtension == NULL && strrchr(inputFileExtension, '.') && strstr(inputFileExtension, handlers[i].inputFileExtension)))
         {


### PR DESCRIPTION
This resolves a build error users were experiencing concerning `pow()`

Also adds functionality to pass `json` files as input for the `-cell` option for `NCGR` <-> `png`