### PR TITLE
Separate Scan and Encode arguments for NCGRs

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -954,7 +954,7 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int
         FATAL_ERROR("Failed to open \"%s\" for writing.\n", path);
 
     int tileSize = bitDepth * 8; // number of bytes per tile
-    if (bitDepth == 8 && convertTo4Bpp && !scanMode)
+    if (bitDepth == 8 && convertTo4Bpp && !scan)
         tileSize /= 2;
 
     if (image->width % 8 != 0)

--- a/gfx.h
+++ b/gfx.h
@@ -51,12 +51,12 @@ struct Image {
 };
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack);
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, uint32_t encodeMode);
 void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
-                   bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, uint32_t scanMode,
-                   uint32_t mappingType, uint32_t key, bool wrongSize);
+                   bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, bool scan,
+                   uint32_t mappingType, uint32_t key, bool wrongSize, uint32_t encodeMode);
 void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
 void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool inverted);

--- a/main.c
+++ b/main.c
@@ -359,6 +359,13 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
             if (options.rowsPerChunk < 1)
                 FATAL_ERROR("rows per chunk must be positive.\n");
         }
+        else if (strcmp(option, "-scanfronttoback") == 0)
+        {
+            // maintained for compatibility
+            if (options.encodeMode != 0)
+                FATAL_ERROR("Encode mode specified more than once.\n-encodebacktofront goes back to front as in DP, -encodefronttoback goes front to back as in PtHGSS\n");
+            options.encodeMode = 2;
+        }
         else if (strcmp(option, "-encodebacktofront") == 0)
         {
             if (options.encodeMode != 0)
@@ -558,6 +565,22 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
         else if (strcmp(option, "-sopc") == 0)
         {
             options.sopc = true;
+        }
+        else if (strcmp(option, "-scanned") == 0)
+        {
+            // maintained for compatibility
+            if (options.encodeMode != 0)
+                FATAL_ERROR("Encode mode specified more than once.\n-encodebacktofront goes back to front as in DP, -encodefronttoback goes front to back as in PtHGSS\n");
+            options.encodeMode = 1;
+            options.scan = true;
+        }
+        else if (strcmp(option, "-scanfronttoback") == 0)
+        {
+            // maintained for compatibility
+            if (options.encodeMode != 0)
+                FATAL_ERROR("Encode mode specified more than once.\n-encodebacktofront goes back to front as in DP, -encodefronttoback goes front to back as in PtHGSS\n");
+            options.encodeMode = 2;
+            options.scan = true;
         }
         else if (strcmp(option, "-encodebacktofront") == 0)
         {

--- a/options.h
+++ b/options.h
@@ -33,11 +33,12 @@ struct PngToNtrOptions {
     bool byteOrder;
     bool version101;
     bool sopc;
-    uint32_t scanMode;
+    bool scan;
     bool wrongSize;
     bool handleEmpty;
     bool vramTransfer;
     int mappingType;
+    uint32_t encodeMode;
 };
 
 struct NtrToPngOptions {
@@ -49,8 +50,8 @@ struct NtrToPngOptions {
     int colsPerChunk;
     int rowsPerChunk;
     int palIndex;
-    bool scanFrontToBack;
     bool handleEmpty;
+    uint32_t encodeMode;
 };
 
 struct CellVramTransferData {


### PR DESCRIPTION
Separates scan and encode into separate `NCGR` <-> `PNG` options. This changes the relevant arguments from:
`-scanned`
`-scanfronttoback`
to:
`-scan`
`-encodebacktofront`
`-encodefronttoback`


There is also a small catch case change for oamSize to resolve warnings some users were experiencing.