### PR TITLE
output coords as signed values

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -795,15 +795,15 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG)
                 break;
             }
 
-            int x = options->cells[i]->oam[j].attr1.XCoordinate; // 8 bits
-            if ((x & 0x80) != 0)
+            int x = options->cells[i]->oam[j].attr1.XCoordinate;
+            if (x & (1 << 8))
             {
-                x = (x | ~0xFF);
+                x |= ~0x1FF;
             }
-            int y = options->cells[i]->oam[j].attr0.YCoordinate; // 7 bits
-            if ((y & 0x40) != 0)
+            int y = options->cells[i]->oam[j].attr0.YCoordinate;
+            if (y & (1 << 7))
             {
-                y = (y | ~0x7F);
+                y |= ~0xFF;
             }
             x -= options->cells[i]->minX;
             y -= options->cells[i]->minY;

--- a/json.c
+++ b/json.c
@@ -174,7 +174,12 @@ struct JsonToCellOptions *ParseNCERJson(char *path)
             cJSON *Colours = cJSON_GetObjectItemCaseSensitive(Attr0, "Colours");
             cJSON *Shape = cJSON_GetObjectItemCaseSensitive(Attr0, "Shape");
 
-            options->cells[i]->oam[j].attr0.YCoordinate = GetInt(YCoordinate);
+            int y = GetInt(YCoordinate);
+            if (y & (1 << 7))
+            {
+                y &= 0xFF;
+            }
+            options->cells[i]->oam[j].attr0.YCoordinate = y;
             options->cells[i]->oam[j].attr0.Rotation = GetBool(Rotation);
             options->cells[i]->oam[j].attr0.SizeDisable = GetBool(SizeDisable);
             options->cells[i]->oam[j].attr0.Mode = GetInt(Mode);
@@ -189,7 +194,12 @@ struct JsonToCellOptions *ParseNCERJson(char *path)
             cJSON *RotationScaling = cJSON_GetObjectItemCaseSensitive(Attr1, "RotationScaling");
             cJSON *Size = cJSON_GetObjectItemCaseSensitive(Attr1, "Size");
 
-            options->cells[i]->oam[j].attr1.XCoordinate = GetInt(XCoordinate);
+            int x = GetInt(XCoordinate);
+            if (x & (1 << 8))
+            {
+                x &= 0x1FF;
+            }
+            options->cells[i]->oam[j].attr1.XCoordinate = x;
             options->cells[i]->oam[j].attr1.RotationScaling = GetInt(RotationScaling);
             options->cells[i]->oam[j].attr1.Size = GetInt(Size);
 
@@ -257,7 +267,12 @@ char *GetNCERJson(struct JsonToCellOptions *options)
 
             cJSON *Attr0 = cJSON_AddObjectToObject(OAM, "Attr0");
 
-            cJSON_AddNumberToObject(Attr0, "YCoordinate", options->cells[i]->oam[j].attr0.YCoordinate);
+            int y = options->cells[i]->oam[j].attr0.YCoordinate;
+            if (y & (1 << 7))
+            {
+                y |= ~0xFF;
+            }
+            cJSON_AddNumberToObject(Attr0, "YCoordinate", y);
             cJSON_AddBoolToObject(Attr0, "Rotation", options->cells[i]->oam[j].attr0.Rotation);
             cJSON_AddBoolToObject(Attr0, "SizeDisable", options->cells[i]->oam[j].attr0.SizeDisable);
             cJSON_AddNumberToObject(Attr0, "Mode", options->cells[i]->oam[j].attr0.Mode);
@@ -267,7 +282,12 @@ char *GetNCERJson(struct JsonToCellOptions *options)
 
             cJSON *Attr1 = cJSON_AddObjectToObject(OAM, "Attr1");
 
-            cJSON_AddNumberToObject(Attr1, "XCoordinate", options->cells[i]->oam[j].attr1.XCoordinate);
+            int x = options->cells[i]->oam[j].attr1.XCoordinate;
+            if (x & (1 << 8))
+            {
+                x |= ~0x1FF;
+            }
+            cJSON_AddNumberToObject(Attr1, "XCoordinate", x);
             cJSON_AddNumberToObject(Attr1, "RotationScaling", options->cells[i]->oam[j].attr1.RotationScaling);
             cJSON_AddNumberToObject(Attr1, "Size", options->cells[i]->oam[j].attr1.Size);
 


### PR DESCRIPTION
fixes https://github.com/red031000/nitrogfx/issues/33

from my testing, existing json files that have unsigned coords will still work fine when converted back to NCER

also treats the x coord as a 9-bit value rather than 8, and the y coord as an 8-bit value rather than 7. this seems to be correct and is necessary to make the round trip back to NCER