### PR TITLE
add verbose flag

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -555,7 +555,7 @@ void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int ro
     free(buffer);
 }
 
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex)
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex, bool verbose)
 {
     int fileSize;
     unsigned char *buffer = ReadWholeFile(path, &fileSize);
@@ -577,6 +577,41 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk,
     unsigned char *imageData = charHeader + 0x20;
 
     bool scanned = charHeader[0x14];
+
+    if (verbose)
+    {
+        if (!convertTo8Bpp) {
+            printf("-bitdepth %d ", bitDepth);
+        } else {
+            printf("-convertTo4Bpp ");
+        }
+
+        if (buffer[0x6] == 1) {
+            printf("-version101 ");
+        }
+
+        if (charHeader[0x8] == 0xFF && charHeader[0x9] == 0xFF && charHeader[0xA] == 0xFF && charHeader[0xB] == 0xFF)
+        {
+            printf("-clobbersize ");
+        }
+
+        if (buffer[0xE] == 2) {
+            printf("-sopc ");
+        }
+
+        if (charHeader[0x12]) {
+            printf("-mappingtype %d ", 1 << (5 + (charHeader[0x12] >> 4)));
+        }
+
+        if (scanned)
+        {
+            printf("-scanned ");
+        }
+
+        if (charHeader[0x15] == 1) {
+            printf("-vram ");
+        }
+    }
 
     if (bitDepth == 4 && (scanned || !convertTo8Bpp))
     {

--- a/gfx.h
+++ b/gfx.h
@@ -51,7 +51,7 @@ struct Image {
 };
 
 void ReadImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
-uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex);
+uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors, bool scanFrontToBack, bool convertTo8Bpp, int palIndex, bool verbose);
 void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool snap);
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,

--- a/main.c
+++ b/main.c
@@ -87,7 +87,7 @@ void ConvertNtrToPng(char *inputPath, char *outputPath, struct NtrToPngOptions *
         image.hasPalette = false;
     }
 
-    uint32_t key = ReadNtrImage(inputPath, options->width, 0, options->colsPerChunk, options->rowsPerChunk, &image, !image.hasPalette, options->scanFrontToBack, options->convertTo8Bpp, options->palIndex);
+    uint32_t key = ReadNtrImage(inputPath, options->width, 0, options->colsPerChunk, options->rowsPerChunk, &image, !image.hasPalette, options->scanFrontToBack, options->convertTo8Bpp, options->palIndex, options->verbose);
 
     if (key)
     {
@@ -283,6 +283,7 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
     options.scanFrontToBack = false;
     options.handleEmpty = false;
     options.convertTo8Bpp = false;
+    options.verbose = false;
 
     for (int i = 3; i < argc; i++)
     {
@@ -382,6 +383,10 @@ void HandleNtrToPngCommand(char *inputPath, char *outputPath, int argc, char **a
         else if (strcmp(option, "-convertTo8Bpp") == 0)
         {
             options.convertTo8Bpp = true;
+        }
+        else if (strcmp(option, "-verbose") == 0)
+        {
+            options.verbose = true;
         }
         else
         {

--- a/options.h
+++ b/options.h
@@ -55,6 +55,7 @@ struct NtrToPngOptions {
     bool scanFrontToBack;
     bool handleEmpty;
     bool convertTo8Bpp;
+    bool verbose;
 };
 
 struct CellVramTransferData {


### PR DESCRIPTION
adds the flag `-verbose`, which can be used when converting from NCGR to png to print out the flags necessary to recreate the NCGR (ie. "-clobbersize", "-sopc", etc.)

