### PR TITLE
Extend `-width` flag usage to override existing dimensions

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -604,6 +604,10 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk,
             printf("-vram ");
         }
 
+        if (tilesWide && ReadS16(charHeader, 0xA) != 0xFF) {
+            printf("-width %d ", ReadS16(charHeader, 0xA));
+        }
+
         puts(""); // at least 1 line is always output (-bitdepth / -convertTo4Bpp)
     }
 
@@ -616,18 +620,21 @@ uint32_t ReadNtrImage(char *path, int tilesWide, int bitDepth, int colsPerChunk,
     if (bitDepth == 4 && convertTo8Bpp && !scanned)
         tileSize *= 2;
 
+    int numTiles = ReadS32(charHeader, 0x18) / (64 / (8 / bitDepth));
+
+    int tilesTall;
     if (tilesWide == 0) {
         tilesWide = ReadS16(charHeader, 0xA);
         if (tilesWide < 0) {
             tilesWide = 1;
         }
+        tilesTall = ReadS16(charHeader, 0x8);
+        if (tilesTall < 0) {
+            tilesTall = (numTiles + tilesWide - 1) / tilesWide;
+        }
+    } else {
+        tilesTall = numTiles / tilesWide + (numTiles % tilesWide != 0);
     }
-
-    int numTiles = ReadS32(charHeader, 0x18) / (64 / (8 / bitDepth));
-
-    int tilesTall = ReadS16(charHeader, 0x8);
-    if (tilesTall < 0)
-        tilesTall = (numTiles + tilesWide - 1) / tilesWide;
 
     if (tilesWide % colsPerChunk != 0)
         FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
@@ -1100,7 +1107,8 @@ void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int ro
 
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, bool scan,
-                   uint32_t encodeMode, uint32_t mappingType, uint32_t key, bool wrongSize, bool convertTo4Bpp, int rotate)
+                   uint32_t encodeMode, uint32_t mappingType, uint32_t key, bool wrongSize, bool convertTo4Bpp, int rotate,
+                   int tilesWide)
 {
     FILE *fp = fopen(path, "wb");
 
@@ -1117,8 +1125,24 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int
     if (image->height % 8 != 0)
         FATAL_ERROR("The height in pixels (%d) isn't a multiple of 8.\n", image->height);
 
-    int tilesWide = image->width / 8; // how many tiles wide the image is
-    int tilesTall = image->height / 8; // how many tiles tall the image is
+    int pngTilesWide = image->width / 8; // how many tiles wide the image is
+    int pngTilesTall = image->height / 8; // how many tiles tall the image is
+    int pngNumTiles = pngTilesWide * pngTilesTall;
+
+    if (numTiles == 0)
+        numTiles = pngNumTiles;
+    else if (numTiles > pngNumTiles)
+        FATAL_ERROR("The specified number of tiles (%d) is greater than the maximum possible value (%d).\n", numTiles, pngNumTiles);
+
+    int tilesTall;
+    if (tilesWide == 0) {
+        tilesWide = pngTilesWide;
+        tilesTall = pngTilesTall;
+    } else {
+        if (numTiles % tilesWide != 0)
+            FATAL_ERROR("The number of tiles (%d) is not a multiple of the width in tiles (%d).\n", numTiles, tilesWide);
+        tilesTall = numTiles / tilesWide;
+    }
 
     if (tilesWide % colsPerChunk != 0)
         FATAL_ERROR("The width in tiles (%d) isn't a multiple of the specified tiles per row (%d)", tilesWide, colsPerChunk);
@@ -1126,20 +1150,13 @@ void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int
     if (tilesTall % rowsPerChunk != 0)
         FATAL_ERROR("The height in tiles (%d) isn't a multiple of the specified rows per chunk (%d)", tilesTall, rowsPerChunk);
 
-    int maxNumTiles = tilesWide * tilesTall;
-
-    if (numTiles == 0)
-        numTiles = maxNumTiles;
-    else if (numTiles > maxNumTiles)
-        FATAL_ERROR("The specified number of tiles (%d) is greater than the maximum possible value (%d).\n", numTiles, maxNumTiles);
-
     int bufferSize = numTiles * tileSize;
     unsigned char *pixelBuffer = malloc(bufferSize);
 
     if (pixelBuffer == NULL)
         FATAL_ERROR("Failed to allocate memory for pixels.\n");
 
-    int chunksWide = tilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
+    int chunksWide = pngTilesWide / colsPerChunk; // how many chunks side-by-side are needed for the full width of the image
 
     if (scan)
     {

--- a/gfx.h
+++ b/gfx.h
@@ -56,7 +56,7 @@ void ApplyCellsToImage(char *cellFilePath, struct Image *image, bool toPNG, bool
 void WriteImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, const char *embedName, struct Image *image, bool invertColors);
 void WriteNtrImage(char *path, int numTiles, int bitDepth, int colsPerChunk, int rowsPerChunk, struct Image *image,
                    bool invertColors, bool clobberSize, bool byteOrder, bool version101, bool sopc, bool vram, bool scan,
-                   uint32_t encodeMode, uint32_t mappingType, uint32_t key, bool wrongSize, bool convertTo4Bpp, int rotate);
+                   uint32_t encodeMode, uint32_t mappingType, uint32_t key, bool wrongSize, bool convertTo4Bpp, int rotate, int tilesWide);
 void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
 void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool convertTo8Bpp, bool verbose);

--- a/main.c
+++ b/main.c
@@ -183,7 +183,7 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
     WriteNtrImage(outputPath, options->numTiles, options->bitDepth, options->colsPerChunk, options->rowsPerChunk,
                   &image, !image.hasPalette, options->clobberSize, options->byteOrder, options->version101,
                   options->sopc, options->vramTransfer, options->scan, options->encodeMode, options->mappingType,
-                  key, options->wrongSize, options->convertTo4Bpp, options->rotate);
+                  key, options->wrongSize, options->convertTo4Bpp, options->rotate, options->tilesWide);
 
     FreeImage(&image);
 }
@@ -519,6 +519,7 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
     options.cellFilePath = NULL;
     options.cellSnap = true;
     options.numTiles = 0;
+    options.tilesWide = 0;
     options.bitDepth = 0;
     options.colsPerChunk = 1;
     options.rowsPerChunk = 1;
@@ -590,6 +591,19 @@ void HandlePngToNtrCommand(char *inputPath, char *outputPath, int argc, char **a
                     break;
                 }
             }
+        }
+        else if (strcmp(option, "-width") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No number of tiles following \"-width\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &options.tilesWide))
+                FATAL_ERROR("Failed to parse tile width.\n");
+
+            if (options.tilesWide < 1)
+                FATAL_ERROR("Tile width must be positive.\n");
         }
         else if (strcmp(option, "-mwidth") == 0 || strcmp(option, "-cpc") == 0)
         {

--- a/options.h
+++ b/options.h
@@ -28,6 +28,7 @@ struct PngToNtrOptions {
     char *cellFilePath;
     bool cellSnap;
     int numTiles;
+    int tilesWide;
     int bitDepth;
     int colsPerChunk;
     int rowsPerChunk;


### PR DESCRIPTION
*This change was first implemented and used in https://github.com/pret/pokeplatinum/pull/1058, and was additionally used in https://github.com/pret/pokeplatinum/pull/1062.*

There are some NCGR graphics that have a defined width and height different from those actually used in game/different from the ideal dimensions to actually display the graphic. An example of this is the Network Icon graphics in Pokemon Platinum, which have a defined width of 16 and height of 1, but ideally should have a width of 2 and height of 8 for best viewing. 

The existing `-width` flag in nitrogfx is only meant to handle NCGRs where width and height are undefined (0xFFFF). If `-width` is used on a NCGR where width and height are defined, the width is overridden but the height is not, leading to incorrect dimensions and possible memory issues.

The first goal of this PR is to add support for the `-width` flag to override dimensions on any NCGR, even those with dimensions defined, like the Network Icon graphics. It uses the provided width with the total number of tiles pulled from the NCGR to compute a new height. The final row of the resulting PNG will be padded with empty tiles if `total number of tiles % width != 0`.

*Default PNG*
<img width="128" height="8" alt="bad" src="https://github.com/user-attachments/assets/9d62376e-0b21-40da-94dc-1dc7985a14b8" />

*PNG built with  `-width 2`*
<img width="16" height="64" alt="local_connection" src="https://github.com/user-attachments/assets/3456f1f9-4121-4f52-aad3-b2cdd58bf658" />

The second goal of this PR is to then add a `-width` flag for the conversion of PNG back to NCGR to reverse the process. To accomplish this, I reordered the code slightly to compute the total number of tiles based on the PNG's dimensions, and then again compute the height based on the provided width. This new `-width` flag can be used in conjunction with the already existing `-num_tiles` flag to undo any extra padding tiles introduced in the NCGR->PNG conversion.