### PR TITLE
Allow creation of an empty output NCGR when the input PNG doesn't exist

### DIFF
--- a/main.c
+++ b/main.c
@@ -133,23 +133,25 @@ void ConvertPngToNtr(char *inputPath, char *outputPath, struct PngToNtrOptions *
     if (options->handleEmpty)
     {
         FILE *fp = fopen(inputPath, "rb");
+        uint32_t size = 0;
         if (fp != NULL)
         {
             fseek(fp, 0, SEEK_END);
-            uint32_t size = ftell(fp);
+            size = ftell(fp);
             rewind(fp);
-            if (size == 0)
+        }
+
+        if (size == 0)
+        {
+            FILE *out = fopen(outputPath, "wb+");
+            if (out != NULL)
             {
-                FILE *out = fopen(outputPath, "wb+");
-                if (out != NULL)
-                {
-                    fclose(out);
-                }
-                fclose(fp);
-                return;
+                fclose(out);
             }
             fclose(fp);
+            return;
         }
+        fclose(fp);
     }
 
     struct Image image;


### PR DESCRIPTION
This is an extension feature to make the tool more scriptable. Sometimes, an input file doesn't exist for whatever reason, but should not be treated as an invalid command. Instead, that case should create an empty output file as a stand-in.

One active example is the front-and-back sprites for individual species in the Generation 4 Pokemon games, which are split into male and female variants. Some species do not have one of these variants (e.g., Tauros does not have female sprites), which is represented in the packed NARC as a zero-width member-file. Instead of storing an invalid PNG to account for such cases, we can pass `-handleempty` to the conversion routine and have it effectively act as a `touch` command.

This code could probably do with some refactoring to remove an extraneous-open on the input file, but that can be part of a separate effort.