### PR TITLE
add support for extended palettes

### DIFF
--- a/gfx.c
+++ b/gfx.c
@@ -1372,6 +1372,7 @@ void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIn
 {
     int fileSize;
     bool inverted = false;
+    palette->extendedLength = 0;
     unsigned char *data = ReadWholeFile(path, &fileSize);
 
     if (memcmp(data, "RLCN", 4) != 0 && memcmp(data, "RPCN", 4) != 0) //NCLR / NCPR
@@ -1403,11 +1404,15 @@ void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIn
         inverted = true;
     }
 
-    if (palIndex == 0) {
+    if (palIndex == 0 || convertTo8Bpp) {
         palette->numColors = paletteSize / 2;
     } else {
-        palette->numColors = bitdepth == 4 && !convertTo8Bpp ? 16 : 256; //remove header and divide by 2
+        palette->numColors = bitdepth == 4 ? 16 : 256; //remove header and divide by 2
         --palIndex;
+    }
+
+    if (paletteHeader[0xC] == 1) {
+        palette->extendedLength = palette->numColors / 256;
     }
 
     unsigned char *paletteData = paletteHeader + PLTT_HEADER_SIZE;
@@ -1426,6 +1431,25 @@ void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIn
             palette->colors[i].red = 0;
             palette->colors[i].green = 0;
             palette->colors[i].blue = 0;
+        }
+    }
+
+    if (convertTo8Bpp)
+    {
+        palette->numColors = 256;
+    }
+
+    if (palette->extendedLength)
+    {
+        for (int i = 1; i < palette->extendedLength; i++)
+        {
+            for (int j = 0; j < 256; j++)
+            {
+                uint16_t paletteEntry = (paletteData[(32 * (convertTo8Bpp ? 0 : palIndex)) + i * 512 + j * 2 + 1] << 8) | paletteData[(32 * (convertTo8Bpp ? 0 : palIndex)) + i * 512 + j * 2];
+                palette->extendedColors[i - 1][j].red = UPCONVERT_BIT_DEPTH(GET_GBA_PAL_RED(paletteEntry));
+                palette->extendedColors[i - 1][j].green = UPCONVERT_BIT_DEPTH(GET_GBA_PAL_GREEN(paletteEntry));
+                palette->extendedColors[i - 1][j].blue = UPCONVERT_BIT_DEPTH(GET_GBA_PAL_BLUE(paletteEntry));
+            }
         }
     }
 
@@ -1453,6 +1477,10 @@ void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIn
         uint16_t sectionCount = (data[0x0F] << 8) | data[0x0E];
         if (sectionCount == 2) {
             printf("-pcmp ");
+        }
+
+        if (palette->extendedLength) {
+            printf("-extended %d ", palette->extendedLength);
         }
 
         printf("-bitdepth %d ", bitdepth);
@@ -1483,14 +1511,14 @@ void WriteGbaPalette(char *path, struct Palette *palette)
     fclose(fp);
 }
 
-void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, int pcmpStartIndex, bool inverted, bool convertTo4Bpp)
+void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, int pcmpStartIndex, bool inverted, bool convertTo4Bpp, int extendedLength)
 {
     FILE *fp = fopen(path, "wb");
 
     if (fp == NULL)
         FATAL_ERROR("Failed to open \"%s\" for writing.\n", path);
 
-    int colourNum = pad ? 256 : palette->numColors;
+    int colourNum = pad && !extendedLength ? 256 : palette->numColors;
 
     uint32_t size = colourNum * 2; //todo check if there's a better way to detect :/
     uint32_t extSize = size + (ncpr ? 0x10 : 0x18);
@@ -1536,6 +1564,11 @@ void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, in
         palHeader[10] = compNum; //assuming this is an indicator of compression, literally no docs for it though
     }
 
+    if (extendedLength)
+    {
+        palHeader[12] = 1;
+    }
+
     //size
     int colorSize = inverted ? 0x200 - size : size;
     palHeader[16] = colorSize & 0xFF;
@@ -1551,10 +1584,19 @@ void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, in
     {
         if (i < palette->numColors)
         {
-            unsigned char red = DOWNCONVERT_BIT_DEPTH(palette->colors[i].red);
-            unsigned char green = DOWNCONVERT_BIT_DEPTH(palette->colors[i].green);
-            unsigned char blue = DOWNCONVERT_BIT_DEPTH(palette->colors[i].blue);
-
+            unsigned char red, green, blue;
+            if (i < 256)
+            {
+                red = DOWNCONVERT_BIT_DEPTH(palette->colors[i].red);
+                green = DOWNCONVERT_BIT_DEPTH(palette->colors[i].green);
+                blue = DOWNCONVERT_BIT_DEPTH(palette->colors[i].blue);
+            }
+            else
+            {
+                red = DOWNCONVERT_BIT_DEPTH(palette->extendedColors[i / 256 - 1][i % 256].red);
+                green = DOWNCONVERT_BIT_DEPTH(palette->extendedColors[i / 256 - 1][i % 256].green);
+                blue = DOWNCONVERT_BIT_DEPTH(palette->extendedColors[i / 256 - 1][i % 256].blue);
+            }
             uint16_t paletteEntry = SET_GBA_PAL(red, green, blue);
 
             colours[i * 2] = paletteEntry & 0xFF;

--- a/gfx.h
+++ b/gfx.h
@@ -15,8 +15,10 @@ struct Color {
 
 struct Palette {
 	struct Color colors[256];
+    struct Color extendedColors[15][256];
 	int numColors;
 	int bitDepth;
+    int extendedLength;
 };
 
 struct Image {
@@ -61,7 +63,7 @@ void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
 void ReadNtrPalette(char *path, struct Palette *palette, int bitdepth, int palIndex, bool convertTo8Bpp, bool verbose);
 void WriteGbaPalette(char *path, struct Palette *palette);
-void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, int pcmpStartIndex, bool inverted, bool convertTo4Bpp);
+void WriteNtrPalette(char *path, struct Palette *palette, bool ncpr, bool ir, int bitdepth, bool pad, int compNum, bool pcmp, int pcmpStartIndex, bool inverted, bool convertTo4Bpp, int extendedLength);
 void ReadNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrCell(char *path, struct JsonToCellOptions *options);
 void WriteNtrScreen(char *path, struct JsonToScreenOptions *options);

--- a/jasc_pal.c
+++ b/jasc_pal.c
@@ -64,7 +64,7 @@ void ReadJascPaletteLine(FILE *fp, char *line)
     }
 }
 
-void ReadJascPalette(char *path, struct Palette *palette)
+void ReadJascPalette(char *path, struct Palette *palette, int index)
 {
     char line[MAX_LINE_LENGTH + 1];
 
@@ -81,7 +81,7 @@ void ReadJascPalette(char *path, struct Palette *palette)
     ReadJascPaletteLine(fp, line);
 
     if (strcmp(line, "0100") != 0)
-        FATAL_ERROR("Unsuported JASC-PAL version.\n");
+        FATAL_ERROR("Unsupported JASC-PAL version.\n");
 
     ReadJascPaletteLine(fp, line);
 
@@ -145,9 +145,18 @@ void ReadJascPalette(char *path, struct Palette *palette)
         if (blue < 0 || blue > 255)
             FATAL_ERROR("Blue color component (%d) is outside the range [0, 255].\n", blue);
 
-        palette->colors[i].red = red;
-        palette->colors[i].green = green;
-        palette->colors[i].blue = blue;
+        if (index == 0)
+        {
+            palette->colors[i].red = red;
+            palette->colors[i].green = green;
+            palette->colors[i].blue = blue;
+        }
+        else
+        {
+            palette->extendedColors[index - 1][i].red = red;
+            palette->extendedColors[index - 1][i].green = green;
+            palette->extendedColors[index - 1][i].blue = blue;
+        }
         if (i >= 16)
         {
             if (red || green || blue)
@@ -161,18 +170,29 @@ void ReadJascPalette(char *path, struct Palette *palette)
     fclose(fp);
 }
 
-void WriteJascPalette(char *path, struct Palette *palette)
+void WriteJascPalette(char *path, struct Palette *palette, int index)
 {
     FILE *fp = fopen(path, "wb");
+    int numColors = palette->extendedLength ? 256 : palette->numColors;
 
     fputs("JASC-PAL\r\n", fp);
     fputs("0100\r\n", fp);
-    fprintf(fp, "%d\r\n", palette->numColors);
 
-    for (int i = 0; i < palette->numColors; i++)
+    if (index == 0)
     {
-        struct Color *color = &palette->colors[i];
-        fprintf(fp, "%d %d %d\r\n", color->red, color->green, color->blue);
+        for (int i = 0; i < numColors; i++)
+        {
+            struct Color *color = &palette->colors[i];
+            fprintf(fp, "%d %d %d\r\n", color->red, color->green, color->blue);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < numColors; i++)
+        {
+            struct Color *color = &palette->extendedColors[index - 1][i];
+            fprintf(fp, "%d %d %d\r\n", color->red, color->green, color->blue);
+        }
     }
 
     fclose(fp);

--- a/jasc_pal.h
+++ b/jasc_pal.h
@@ -3,7 +3,7 @@
 #ifndef JASC_PAL_H
 #define JASC_PAL_H
 
-void ReadJascPalette(char *path, struct Palette *palette);
-void WriteJascPalette(char *path, struct Palette *palette);
+void ReadJascPalette(char *path, struct Palette *palette, int index);
+void WriteJascPalette(char *path, struct Palette *palette, int index);
 
 #endif // JASC_PAL_H

--- a/main.c
+++ b/main.c
@@ -843,7 +843,7 @@ void HandlePngToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, c
     }
 
     ReadPngPalette(inputPath, &palette);
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, pcmpStartIndex, inverted, convertTo4Bpp);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, pcmpStartIndex, inverted, convertTo4Bpp, false);
 }
 
 void HandleGbaToJascPaletteCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)
@@ -851,7 +851,7 @@ void HandleGbaToJascPaletteCommand(char *inputPath, char *outputPath, int argc U
     struct Palette palette;
 
     ReadGbaPalette(inputPath, &palette);
-    WriteJascPalette(outputPath, &palette);
+    WriteJascPalette(outputPath, &palette, 0);
 }
 
 void HandleNtrToJascPaletteCommand(char *inputPath, char *outputPath, int argc, char **argv)
@@ -888,7 +888,20 @@ void HandleNtrToJascPaletteCommand(char *inputPath, char *outputPath, int argc, 
     }
 
     ReadNtrPalette(inputPath, &palette, bitdepth, 0, false, verbose);
-    WriteJascPalette(outputPath, &palette);
+    if (!palette.extendedLength)
+    {
+        WriteJascPalette(outputPath, &palette, 0);
+    }
+    else
+    {
+        int pathLen = strlen(outputPath);
+        char *extendedOutputPath = calloc(pathLen + 4, sizeof(char));
+        for (int i = 0; i < palette.extendedLength; i++)
+        {
+            snprintf(extendedOutputPath, pathLen + 4, "%.*s_%d.pal", pathLen - 4, outputPath, i);
+            WriteJascPalette(extendedOutputPath, &palette, i);
+        }
+    }
 }
 
 void HandleJascToGbaPaletteCommand(char *inputPath, char *outputPath, int argc, char **argv)
@@ -920,7 +933,7 @@ void HandleJascToGbaPaletteCommand(char *inputPath, char *outputPath, int argc, 
 
     struct Palette palette;
 
-    ReadJascPalette(inputPath, &palette);
+    ReadJascPalette(inputPath, &palette, 0);
 
     if (numColors != 0)
         palette.numColors = numColors;
@@ -939,6 +952,7 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     int pcmpStartIndex = 0;
     bool pcmp = false;
     bool inverted = false;
+    int extendedLength = 0;
 
     for (int i = 3; i < argc; i++)
     {
@@ -1013,6 +1027,17 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
         {
             inverted = true;
         }
+        else if (strcmp(option, "-extended") == 0)
+        {
+
+            if (i + 1 >= argc)
+                FATAL_ERROR("No length value following \"-extended\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &extendedLength))
+                FATAL_ERROR("Failed to parse extended length.\n");
+        }
         else
         {
             FATAL_ERROR("Unrecognized option \"%s\".\n", option);
@@ -1020,13 +1045,26 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     }
 
     struct Palette palette;
-
-    ReadJascPalette(inputPath, &palette);
+    if (!extendedLength)
+    {
+        ReadJascPalette(inputPath, &palette, 0);
+    }
+    else
+    {
+        int pathLen = strlen(inputPath);
+        char *extendedInputPath = calloc(pathLen + 4, sizeof(char));
+        for (int i = 0; i < extendedLength; i++)
+        {
+            snprintf(extendedInputPath, pathLen + 4, "%.*s_%d.pal", pathLen - 4, inputPath, i);
+            ReadJascPalette(extendedInputPath, &palette, i);
+        }
+        palette.numColors *= extendedLength;
+    }
 
     if (numColors != 0)
         palette.numColors = numColors;
 
-    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, pcmpStartIndex, inverted, false);
+    WriteNtrPalette(outputPath, &palette, ncpr, ir, bitdepth, !nopad, compNum, pcmp, pcmpStartIndex, inverted, false, extendedLength);
 }
 
 void HandleJsonToNtrCellCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)


### PR DESCRIPTION
some palettes can have extended data beyond the normal 256-colour limit, indicated by offset 0xC in the header being set to 1.

for NCLR -> pal this is handled automatically by splitting the output across multiple 8bpp palettes.

for pal -> NCLR this uses a new `extended` flag with the amount of pal files to read