### PR TITLE
generate padding for extended nclrs

### DIFF
--- a/main.c
+++ b/main.c
@@ -959,6 +959,7 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
     bool pcmp = false;
     bool inverted = false;
     int extendedLength = 0;
+    int paddingType = 0;
 
     for (int i = 3; i < argc; i++)
     {
@@ -1043,6 +1044,16 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
 
             if (!ParseNumber(argv[i], NULL, 10, &extendedLength))
                 FATAL_ERROR("Failed to parse extended length.\n");
+
+            if (i + 2 < argc)
+            {
+                if (strcmp(argv[i + 1], "-paddingtype") == 0)
+                {
+                    i += 2;
+                    if (!ParseNumber(argv[i], NULL, 10, &paddingType))
+                        FATAL_ERROR("Failed to parse extended NCLR padding type.\n");
+                }
+            }
         }
         else
         {
@@ -1061,10 +1072,47 @@ void HandleJascToNtrPaletteCommand(char *inputPath, char *outputPath, int argc, 
         char *extendedInputPath = calloc(pathLen + 4, sizeof(char));
         for (int i = 0; i < extendedLength; i++)
         {
-            snprintf(extendedInputPath, pathLen + 4, "%.*s_%d.pal", pathLen - 4, inputPath, i);
+            snprintf(extendedInputPath, pathLen + 4, "%.*s_%d.pal", pathLen - 6, inputPath, i);
             ReadJascPalette(extendedInputPath, &palette, i);
         }
-        palette.numColors *= extendedLength;
+        if (nopad)
+        {
+            palette.numColors *= extendedLength;
+        }
+        else
+        {
+            palette.numColors *= 16;
+            if (paddingType == 0)
+            {
+                if (extendedLength < 16)
+                    memset(&palette.extendedColors[extendedLength - 1], 0, sizeof(struct Color) * (16 - extendedLength) * 256);
+            }
+            else
+            {
+                for (int i = extendedLength; i < 16; i++)
+                {
+                    int count = 0;
+                    int red = 0;
+                    int green = 0;
+                    for (int j = 0; j < 256; j++)
+                    {
+                        palette.extendedColors[i - 1][j].red = (red * 255) / 31;
+                        palette.extendedColors[i - 1][j].green = (green * 255) / 31;
+                        palette.extendedColors[i - 1][j].blue = 0;
+                        red += i * 2;
+                        if (red >= 32)
+                        {
+                            red &= 0x1F;
+                            if (++count == 8)
+                            {
+                                green++;
+                                count = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     if (numColors != 0)


### PR DESCRIPTION
- extended nclrs will be padded to 4096 colours unless `-nopad` is provided
- by default or if `-paddingtype 0` is provided, this padding will be 0s
- if `-paddingtype 1` is provided, the padding will follow some weird pattern that game freak used